### PR TITLE
Don't force use of HTTPS

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -28,18 +28,6 @@
         <mime-type>application/json</mime-type>
     </mime-mapping>
 
-    <!-- Force SSL for entire site -->
-	<security-constraint>
-	    <web-resource-collection>
-	        <web-resource-name>site</web-resource-name>
-	        <url-pattern>/*</url-pattern>
-	    </web-resource-collection>
-
-	    <user-data-constraint>
-	        <transport-guarantee>CONFIDENTIAL</transport-guarantee>
-	    </user-data-constraint>
-	</security-constraint>
-
     <login-config>
         <auth-method>BASIC</auth-method>
         <realm-name>file</realm-name>


### PR DESCRIPTION
Datagateway Download API will often run behind a reverse proxy which will handle TLS, so we don't need to force the application server to use HTTPS.