### PR TITLE
Add datagateway_admin script

### DIFF
--- a/provision/topcat
+++ b/provision/topcat
@@ -11,7 +11,8 @@ def build_install
 		mkdir ~/topcat_tmp/tools
 		cp /vagrant/tools/topcat_admin ~/topcat_tmp/tools
 		cp /vagrant/tools/topcat_admin_LILS ~/topcat_tmp/tools
-		dos2unix ~/topcat_tmp/tools/topcat_admin ~/topcat_tmp/tools/topcat_admin_LILS
+		cp /vagrant/tools/datagateway_admin ~/topcat_tmp/tools
+		dos2unix ~/topcat_tmp/tools/topcat_admin ~/topcat_tmp/tools/topcat_admin_LILS ~/topcat_tmp/tools/datagateway_admin
 		cp -r /vagrant/src ~/topcat_tmp
 		cp -r /vagrant/provision ~/topcat_tmp
 		cd ~/topcat_tmp

--- a/src/assemble/distribution.xml
+++ b/src/assemble/distribution.xml
@@ -46,6 +46,7 @@
 			<includes>
 				<include>topcat_admin</include>
 				<include>topcat_admin_LILS</include>
+				<include>datagateway_admin</include>
 			</includes>
 		</fileSet>
 

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -23,7 +23,8 @@ prop_list = []
 binDir = actions.getBinDir()
 # topcat_admin can't be used with the local Topcat server, as it needs topcat.json (which we have removed)
 # Add topcat_admin_LILS, which can be used (but only with the local Topcat server)
-binFiles = ["topcat_admin","topcat_admin_LILS"]
+# Add datagateway_admin, which can be used with DataGateway servers
+binFiles = ["topcat_admin","topcat_admin_LILS", "datagateway_admin"]
 
 if arg in ["CONFIGURE", "INSTALL"]:
     actions.configure(prop_name, prop_list)

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -1,0 +1,303 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import requests
+import getpass
+import json
+import re
+
+# python 2/3 compatibility code
+try:
+    input = raw_input
+except NameError:
+    pass
+
+
+# The following appears to be version-sensitive
+# from urllib3.exceptions import InsecureRequestWarning
+
+# Kill the dragon!!
+# If, like me, you are fed up with SSL certificate issues preventing you from connecting to your own machine,
+# then set verifySsl to False here.
+verifySsl=True
+
+if not verifySsl:
+	# Allegedly, this more-specific version should work, but I find that it doesn't:
+	# requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+	# ... so just turn them all off:
+	requests.packages.urllib3.disable_warnings()
+	print("WARNING: SSL certificate verification (and warnings) disabled. This script will blindly trust whatever it connects to.")
+	
+datagateway_url = input("DataGateway url: ")
+
+scigatewaySettingsJson = json.loads(requests.get(datagateway_url + "/settings.json", verify=verifySsl).text)
+datagateway_download_url = re.sub(r"/main.*\.js", "", next(x for x in scigatewaySettingsJson["plugins"] if x["name"] == "datagateway-download")["src"])
+
+# add datagateway_url back in if it's a relative URL
+if datagateway_download_url[0] == "/":
+	datagateway_download_url = datagateway_url + datagateway_download_url
+	
+settingsJson = json.loads(requests.get(datagateway_download_url + "/datagateway-download-settings.json", verify=verifySsl).text)
+
+facility_name = settingsJson["facilityName"]
+
+ids_url = settingsJson["idsUrl"]
+
+topcat_url = settingsJson["downloadApiUrl"]
+
+if "icatUrl" in settingsJson:
+	icat_url = settingsJson["icatUrl"]
+else:
+	icat_url = requests.get(ids_url + "/getIcatUrl", verify=verifySsl).text + "/icat"
+
+icat_properties = json.loads(requests.get(icat_url + "/properties", verify=verifySsl).text)
+
+
+authentication_plugins = []
+for authenticator in icat_properties["authenticators"]:
+	authentication_plugins.append(authenticator["mnemonic"]) 
+
+if len(authentication_plugins) > 1:
+	print("Available authentication plugins: ")
+	for authentication_plugin in authentication_plugins:
+		print(" * " + authentication_plugin)
+
+	authentication_plugin = input("Which authentication plugin?: ")
+else:
+	authentication_plugin = authentication_plugins[0]
+
+username = input("Username: ")
+password = getpass.getpass("Password: ")
+
+auth = json.dumps({
+	"plugin": authentication_plugin,
+	"credentials": [
+		{"username": username},
+		{"password": password}
+	]
+})
+
+try:
+    response = requests.post(icat_url + "/session", {"json": auth}, verify=verifySsl)
+    session_id = json.loads(response.text)["sessionId"]
+except Exception as e:
+    import sys
+    sys.exit("Couldn't determine sessionId: " + str(e) + "; response: " + response.text)
+
+def show_download():
+	download_id = input("Enter download id: ")
+	print(requests.get(topcat_url + "/admin/downloads", params={
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"queryOffset": "where download.id = " + download_id
+	}, verify=verifySsl).text)
+
+
+def list_file_locations():
+	download_id = input("Enter download id: ")
+	output_file_name = input("Output file name (optional): ")
+	download = json.loads(requests.get(topcat_url + "/admin/downloads", params={
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"queryOffset": "where download.id = " + download_id
+	}, verify=verifySsl).text)[0]
+	download_items = download["downloadItems"]
+	datafile_locations = []
+	for download_item in download_items:
+		if download_item["entityType"] == "investigation":
+			datafile_locations.extend(json.loads(requests.get(icat_url + "/entityManager", params={
+				"sessionId": session_id,
+				"query": "select datafile.location from Datafile datafile, datafile.dataset as dataset, dataset.investigation as investigation where investigation.id = " + str(download_item["entityId"])
+			}, verify=verifySsl).text))
+		elif download_item["entityType"] == "dataset":
+			datafile_locations.extend(json.loads(requests.get(icat_url + "/entityManager", params={
+				"sessionId": session_id,
+				"query": "select datafile.location from Datafile datafile, datafile.dataset as dataset where dataset.id = " + str(download_item["entityId"])
+			}, verify=verifySsl).text))
+		elif download_item["entityType"] == "datafile":
+			datafile_locations.extend(json.loads(requests.get(icat_url + "/entityManager", params={
+				"sessionId": session_id,
+				"query": "select datafile.location from Datafile datafile where datafile.id = " + str(download_item["entityId"])
+			}, verify=verifySsl).text))
+	datafile_locations.sort()
+	if output_file_name != "":
+		file  = open(output_file_name, "w")
+		for datafile_location in datafile_locations:
+			file.write(datafile_location + "\n")
+		file.close()
+	else:
+		for datafile_location in datafile_locations:
+			print(datafile_location)
+
+
+def prepare_download():
+	download_id = input("Enter download id: ")
+	investigation_ids = []
+	dataset_ids = []
+	datafile_ids = []
+	download = json.loads(requests.get(topcat_url + "/admin/downloads", params={
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"queryOffset": "where download.id = " + download_id
+	}, verify=verifySsl).text)[0]
+	download_items = download["downloadItems"]
+	for download_item in download_items:
+		if download_item["entityType"] == "investigation":
+			investigation_ids.append(download_item["entityId"])
+		elif download_item["entityType"] == "dataset":
+			dataset_ids.append(download_item["entityId"])
+		elif download_item["entityType"] == "datafile":
+			datafile_ids.append(download_item["entityId"])
+	params = {
+		"zip": "true",
+		"sessionId": session_id
+	}
+	if (len(investigation_ids) > 0):
+		params["investigationIds"] = ",".join(map(str, investigation_ids))
+	if (len(dataset_ids) > 0):
+		params["datasetIds"] = ",".join(map(str, dataset_ids))
+	if (len(datafile_ids) > 0):
+		params["datafileIds"] = ",".join(map(str, datafile_ids))
+	prepared_id = requests.post(ids_url + "/prepareData", data=params, verify=verifySsl).text
+	print("")
+	print("UPDATE DOWNLOAD set PREPARED_ID = '" + prepared_id + "', STATUS = 'RESTORING' WHERE ID = " + download_id)
+
+
+
+
+def expire_download():
+	download_id = input("Enter download id: ")
+	requests.put(topcat_url + "/admin/download/" + download_id +  "/status", data={
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"value": "EXPIRED"
+	}, verify=verifySsl)
+
+def expire_all_pending_downloads():
+	query = "(download.status like 'PREPARING' or download.status like 'RESTORING') and download.isDeleted = false"
+
+	query += " and download.facilityName = '" + facility_name + "'"
+
+	downloads = json.loads(requests.get(topcat_url + "/admin/downloads", params={
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"queryOffset": query
+	}, verify=verifySsl).text)
+	for download in  downloads:
+		requests.put(topcat_url + "/admin/download/" + str(download["id"]) +  "/status", data={
+			"facilityName": facility_name,
+			"sessionId": session_id,
+			"value": "EXPIRED"
+		}, verify=verifySsl)
+
+def manage_download_types():
+	download_types = list(settingsJson["accessMethods"])
+	download_statuses = []
+	for download_type in download_types:
+		response = requests.get(topcat_url + "/user/downloadType/" + str(download_type) + "/status", params={
+				"facilityName": facility_name,
+				"sessionId": session_id
+			}, verify=verifySsl)
+		if response:
+			download_status = json.loads(response.text)
+			download_statuses.append(download_status)
+		else:
+			print("Response for '" + str(download_type) + "' not OK: " + str(response.status_code) + ", " + response.text)
+			print("Treating this download type as enabled")
+			download_statuses.append({"disabled":False,"message":""})
+	while True:
+		print("Current download type statuses:")
+		for i, download_type in enumerate(download_types):
+			report = download_type
+			if download_statuses[i]["disabled"]:
+				report += " (disabled, '" + download_statuses[i]["message"] + "')"
+			else:
+				report += " (enabled)"
+			print(str(i+1) + ": " + report)
+		print()
+		# Will a Topcat administrator ever be dumb enough to input a non-number here?
+		try:
+			option_number = int(input("Choose a number to toggle that download type's status, or 0 to exit: "))
+		except ValueError:
+			# this will trigger the Invalid Input response below
+			option_number = -1
+		if option_number == 0: break
+		option_number = option_number - 1
+		if option_number not in range(len(download_types)):
+			print("Invalid input")
+			# We break here rather than continue, so if correct input is impossible at least we escape
+			break
+		download_type = download_types[option_number]
+		download_status = download_statuses[option_number]
+		if download_status["disabled"]:
+			# Note: we don't reset the message - possible option to reuse it in future?
+			response = requests.put(topcat_url + "/admin/downloadType/" + str(download_type) + "/status", data={
+				"facilityName": facility_name,
+				"sessionId": session_id,
+				"disabled": False,
+				"message": download_status["message"]
+			}, verify=verifySsl)
+			if response:
+				print("Enabled download type " + download_type)
+			else:
+				print("Request failed: " + str(response.status_code) + ", " + response.text)
+		else:
+			if download_status["message"]:
+				old_message = download_status["message"]
+				print("Current message for the disabled download type is: " + old_message)
+			else:
+				old_message = ""
+				print("Current message for the disabled download type is: system default")
+			message = input("New message (blank = use current): ")
+			if not len(message) > 0:
+				message = old_message
+			response = requests.put(topcat_url + "/admin/downloadType/" + str(download_type) + "/status", data={
+				"facilityName": facility_name,
+				"sessionId": session_id,
+				"disabled": True,
+				"message": message
+			}, verify=verifySsl)
+			if response:
+				print("Disabled download type " + download_type)
+			else:
+				print("Request failed: " + str(response.status_code) + ", " + response.text)
+		# Update the local copy of the download status
+		# We ASSUME the request is OK
+		download_status = json.loads(requests.get(topcat_url + "/user/downloadType/" + str(download_type) + "/status", params={
+				"facilityName": facility_name,
+				"sessionId": session_id
+			}, verify=verifySsl).text)
+		download_statuses[option_number] = download_status
+
+while True:
+	print("")
+	print("What do you want to do?")
+	print(" * 1: Show download.")
+	print(" * 2: Get a list of all the file locations for a download.")
+	print(" * 3: Create preparedId for a download and generate update SQL.")
+	print(" * 4: Set a download status to 'EXPIRED'.")
+	print(" * 5: Expire all pending downloads.")
+	print(" * 6: Enable or disable download types.")
+	print(" * 7: Exit")
+
+	option_number = input("Enter option number: ");
+
+
+	if option_number == "1":
+		show_download()
+	elif option_number == "2":
+		list_file_locations()
+	elif option_number == "3":
+		prepare_download()
+	elif option_number == "4":
+		expire_download()
+	elif option_number == "5":
+		expire_all_pending_downloads()
+	elif option_number == "6":
+		manage_download_types()
+	elif option_number == "7":
+		break
+	else:
+		print("")
+		print("Unknown option")
+

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -46,7 +46,7 @@ ids_urls = [settingsJson["accessMethods"][x]["idsUrl"] for x in list(settingsJso
 if len(ids_urls) > 1:
 	print("Available IDS servers: ")
 	for i, ids in enumerate(ids_urls):
-		print(f"{i+1}: {ids}")
+		print(str(i+1) + ": " + ids)
 	try:
 		option_number = int(input("Choose a number to select that IDS server: "))
 	except ValueError:
@@ -61,13 +61,13 @@ if len(ids_urls) > 1:
 else:
 	ids_url = settingsJson["idsUrl"]
 
-print(f"IDS url: {ids_url}")
+print("IDS url: " + ids_url)
 
 topcat_url = settingsJson["downloadApiUrl"]
 
 icat_url = requests.get(ids_url + "/getIcatUrl", verify=verifySsl).text + "/icat"
 
-print(f"ICAT url: {icat_url}")
+print("ICAT url: " + icat_url)
 
 icat_properties = json.loads(requests.get(icat_url + "/properties", verify=verifySsl).text)
 

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -41,14 +41,33 @@ settingsJson = json.loads(requests.get(datagateway_download_url + "/datagateway-
 
 facility_name = settingsJson["facilityName"]
 
-ids_url = settingsJson["idsUrl"]
+ids_urls = [settingsJson["accessMethods"][x]["idsUrl"] for x in list(settingsJson["accessMethods"])]
+
+if len(ids_urls) > 1:
+	print("Available IDS servers: ")
+	for i, ids in enumerate(ids_urls):
+		print(f"{i+1}: {ids}")
+	try:
+		option_number = int(input("Choose a number to select that IDS server: "))
+	except ValueError:
+		# this will trigger the Invalid Input response below
+		option_number = -1
+	option_number = option_number - 1
+	if option_number not in range(len(ids_urls)):
+		print("Invalid input,  selecting default IDS")
+		ids_url = settingsJson["idsUrl"]
+	else:
+		ids_url = ids_urls[option_number]
+else:
+	ids_url = settingsJson["idsUrl"]
+
+print(f"IDS url: {ids_url}")
 
 topcat_url = settingsJson["downloadApiUrl"]
 
-if "icatUrl" in settingsJson:
-	icat_url = settingsJson["icatUrl"]
-else:
-	icat_url = requests.get(ids_url + "/getIcatUrl", verify=verifySsl).text + "/icat"
+icat_url = requests.get(ids_url + "/getIcatUrl", verify=verifySsl).text + "/icat"
+
+print(f"ICAT url: {icat_url}")
 
 icat_properties = json.loads(requests.get(icat_url + "/properties", verify=verifySsl).text)
 


### PR DESCRIPTION
Add a new version of the `topcat_admin` script compatible with DataGateway: `datagateway_admin`. This works in the same way as `topcat_admin` - it queries for the frontend's settings file(s) and uses these to get the relevant ICAT stack URLs. You just need to give the URL of the DataGateway server. The only major difference is that we no longer query for facility, as DataGateway is single facility unlike TopCAT.

Additionally, I have tried to make it both Python 2.7 and 3 compatible (as before it only worked on Python 2).