### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from setup_utils import *
 import os

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import requests

--- a/tools/topcat_admin_LILS
+++ b/tools/topcat_admin_LILS
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Version of topcat_admin hard-wired for LILS
 # - having removed topcat.json!


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.