### PR TITLE
Remove topcat_admin from distribution.xml and setup

### DIFF
--- a/src/assemble/distribution.xml
+++ b/src/assemble/distribution.xml
@@ -44,7 +44,6 @@
 			<outputDirectory>topcat</outputDirectory>
 			<directory>${project.basedir}/tools</directory>
 			<includes>
-				<include>topcat_admin</include>
 				<include>topcat_admin_LILS</include>
 				<include>datagateway_admin</include>
 			</includes>

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -25,7 +25,7 @@ binDir = actions.getBinDir()
 # topcat_admin can't be used with the local Topcat server, as it needs topcat.json (which we have removed)
 # Add topcat_admin_LILS, which can be used (but only with the local Topcat server)
 # Add datagateway_admin, which can be used with DataGateway servers
-binFiles = ["topcat_admin","topcat_admin_LILS", "datagateway_admin"]
+binFiles = ["topcat_admin_LILS", "datagateway_admin"]
 
 if arg in ["CONFIGURE", "INSTALL"]:
     actions.configure(prop_name, prop_list)


### PR DESCRIPTION
`topcat_admin` has already been removed. This removes references to it in `distribution.xml` and `setup`.
