### PR TITLE
Switch to secure miredot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
 		<pluginRepository>
 			<id>miredot</id>
 			<name>MireDot Releases</name>
-			<url>http://nexus.qmino.com/content/repositories/miredot</url>
+			<url>https://secure-nexus.miredot.com/content/repositories/miredot</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
Plain http repos are not allowed in recent versions of maven