### PR TITLE
Change artifact name to datagateway-download-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,31 @@
 				</dependencies>
 			</plugin>
 			<plugin>
+				<groupId>com.qmino</groupId>
+				<artifactId>miredot-plugin</artifactId>
+				<version>2.1.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>restdoc</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<licence>cHJvamVjdHxvcmcuaWNhdHByb2plY3QudG9wY2F0fDIwMjYtMDUtMTh8ZmFsc2V8LTEjTUN3Q0ZFRERHS042anNQVUZpOW80Wjdvc2VsVU50djBBaFFvd3lOU0UzWURiSHJmQVluZ0tpeWltbXl3QkE9PQ==</licence>
+					<output>
+						<html>
+							<location>site/miredot</location>
+							<baseUrl>https://example.com/topcat</baseUrl>
+						</html>
+					</output>
+					<!-- apply for spring mvc support <restModel> <restFramework> <name>spring-mvc</name> 
+						</restFramework> </restModel> -->
+					<!-- insert other configuration here (optional) -->
+				</configuration>
+			</plugin>
+
+	        <plugin>
 			    <groupId>org.apache.cxf</groupId>
 			    <artifactId>cxf-codegen-plugin</artifactId>
 			    <version>3.1.11</version>
@@ -282,6 +307,14 @@
 			<url>https://repo.icatproject.org/repo</url>
 		</repository>
 	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>miredot</id>
+			<name>MireDot Releases</name>
+			<url>https://secure-nexus.miredot.com/content/repositories/miredot</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<scm>
 		<connection>scm:git:https://github.com/ral-facilities/datagateway-download-api.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.icatproject</groupId>
-	<artifactId>topcat</artifactId>
+	<artifactId>datagateway-download-api</artifactId>
 	<packaging>war</packaging>
 	<version>2.4.10-SNAPSHOT</version>
-	<name>TopCAT</name>
-	<description>Web frontend for multiple ICATs</description>
+	<name>DataGateway Download API</name>
+	<description>Download backend for DataGateway</description>
 
 	<build>
 
@@ -317,15 +317,15 @@
 	</pluginRepositories>
 
 	<scm>
-		<connection>scm:git:https://github.com/icatproject/topcat.git</connection>
-		<developerConnection>scm:git:https://github.com/icatproject/topcat.git</developerConnection>
-		<url>https://github.com/icatproject/topcat</url>
+		<connection>scm:git:https://github.com/ral-facilities/datagateway-download-api.git</connection>
+		<developerConnection>scm:git:https://github.com/ral-facilities/datagateway-download-api.git</developerConnection>
+		<url>https://github.com/ral-facilities/datagateway-download-api</url>
 		<tag>HEAD</tag>
 	</scm>
 
 
 	<issueManagement>
-		<url>https://github.com/icatproject/topcat/issues</url>
+		<url>https://github.com/ral-facilities/datagateway-download-api/issues</url>
 		<system>GitHub</system>
 	</issueManagement>
 
@@ -345,7 +345,7 @@
 		<downloadUrl>https://repo.icatproject.org/repo</downloadUrl>
 		<site>
 			<id>repo.icatproject.org</id>
-			<url>dav:https://repo.icatproject.org/site/topcat/${project.version}</url>
+			<url>dav:https://repo.icatproject.org/site/datagateway-download-api/${project.version}</url>
 		</site>
 		<repository>
 			<id>repo.icatproject.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -91,31 +91,6 @@
 				</dependencies>
 			</plugin>
 			<plugin>
-				<groupId>com.qmino</groupId>
-				<artifactId>miredot-plugin</artifactId>
-				<version>2.1.2</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>restdoc</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<licence>cHJvamVjdHxvcmcuaWNhdHByb2plY3QudG9wY2F0fDIwMjYtMDUtMTh8ZmFsc2V8LTEjTUN3Q0ZFRERHS042anNQVUZpOW80Wjdvc2VsVU50djBBaFFvd3lOU0UzWURiSHJmQVluZ0tpeWltbXl3QkE9PQ==</licence>
-					<output>
-						<html>
-							<location>site/miredot</location>
-							<baseUrl>https://example.com/topcat</baseUrl>
-						</html>
-					</output>
-					<!-- apply for spring mvc support <restModel> <restFramework> <name>spring-mvc</name> 
-						</restFramework> </restModel> -->
-					<!-- insert other configuration here (optional) -->
-				</configuration>
-			</plugin>
-
-	        <plugin>
 			    <groupId>org.apache.cxf</groupId>
 			    <artifactId>cxf-codegen-plugin</artifactId>
 			    <version>3.1.11</version>
@@ -307,14 +282,6 @@
 			<url>https://repo.icatproject.org/repo</url>
 		</repository>
 	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>miredot</id>
-			<name>MireDot Releases</name>
-			<url>https://secure-nexus.miredot.com/content/repositories/miredot</url>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<scm>
 		<connection>scm:git:https://github.com/ral-facilities/datagateway-download-api.git</connection>


### PR DESCRIPTION
Change artifactId in the POM to datagateway-download-api, and change the SCM to this repo. Remove the miredot plugin because changing the artifactId invalidates the licence key.