### PR TITLE
Mark downloads without preparedIds as PREPARING not RESTORING #40

### DIFF
--- a/src/main/java/org/icatproject/topcat/web/rest/AdminResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/AdminResource.java
@@ -175,7 +175,12 @@ public class AdminResource {
             throw new NotFoundException("could not find download");
         }
 
-        download.setStatus(DownloadStatus.valueOf(value));
+        if (download.getPreparedId() == null && value.equals("RESTORING")) {
+            // Queued jobs need to be marked PREPARING first to generate a preparedId before RESTORING
+            download.setStatus(DownloadStatus.PREPARING);
+        } else {
+            download.setStatus(DownloadStatus.valueOf(value));
+        }
         if(value.equals("COMPLETE")){
             download.setCompletedAt(new Date());
         }

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -237,6 +237,30 @@ public class AdminResourceTest {
 	}
 
 	@Test
+	public void testSetDownloadStatus() throws Exception {
+		Download testDownload = new Download();
+		String facilityName = "LILS";
+		testDownload.setFacilityName(facilityName);
+		testDownload.setSessionId(adminSessionId);
+		testDownload.setStatus(DownloadStatus.PAUSED);
+		testDownload.setIsDeleted(false);
+		testDownload.setUserName("simple/root");
+		testDownload.setFileName("testFile.txt");
+		testDownload.setTransport("http");
+		downloadRepository.save(testDownload);
+
+		Response response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, adminSessionId, DownloadStatus.RESTORING.toString());
+		assertEquals(200, response.getStatus());
+
+		response = adminResource.getDownloads(facilityName, adminSessionId, "1 = 1");
+		assertEquals(200, response.getStatus());
+		List<Download> downloads = (List<Download>) response.getEntity();
+
+		testDownload = findDownload(downloads, testDownload.getId());
+		assertEquals(DownloadStatus.PREPARING, testDownload.getStatus());
+	}
+
+	@Test
 	public void testSetDownloadTypeStatus() throws Exception {
 
 		String facilityName = "LILS";

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -141,9 +141,7 @@ public class AdminResourceTest {
 		downloadRepository.save(testDownload);
 
 		// Get the current downloads - may not be empty
-		// It appears queryOffset cannot be empty!
-		String queryOffset = "1 = 1";
-		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		response = adminResource.getDownloads(facilityName, adminSessionId, null);
 		assertEquals(200, response.getStatus());
 
 		downloads = (List<Download>) response.getEntity();
@@ -151,7 +149,6 @@ public class AdminResourceTest {
 		// Check that the result tallies with the DownloadRepository contents
 
 		Map<String, Object> params = new HashMap<String, Object>();
-		params.put("queryOffset", queryOffset);
 		List<Download> repoDownloads = new ArrayList<Download>();
 		repoDownloads = downloadRepository.getDownloads(params);
 
@@ -171,7 +168,7 @@ public class AdminResourceTest {
 
 		// and test that the new status has been set
 
-		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		response = adminResource.getDownloads(facilityName, adminSessionId, null);
 		assertEquals(200, response.getStatus());
 		downloads = (List<Download>) response.getEntity();
 
@@ -190,7 +187,7 @@ public class AdminResourceTest {
 		// and check that it has worked (again, not bothering to check that nothing else
 		// has changed)
 
-		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		response = adminResource.getDownloads(facilityName, adminSessionId, null);
 		assertEquals(200, response.getStatus());
 		downloads = (List<Download>) response.getEntity();
 
@@ -201,7 +198,7 @@ public class AdminResourceTest {
 		// user
 
 		try {
-			response = adminResource.getDownloads(facilityName, nonAdminSessionId, queryOffset);
+			response = adminResource.getDownloads(facilityName, nonAdminSessionId, null);
 			// We should not see the following
 			System.out.println("DEBUG: AdminRT.getDownloads response: " + response.getStatus() + ", "
 					+ (String) response.getEntity());
@@ -252,7 +249,7 @@ public class AdminResourceTest {
 		Response response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, adminSessionId, DownloadStatus.RESTORING.toString());
 		assertEquals(200, response.getStatus());
 
-		response = adminResource.getDownloads(facilityName, adminSessionId, "1 = 1");
+		response = adminResource.getDownloads(facilityName, adminSessionId, null);
 		assertEquals(200, response.getStatus());
 		List<Download> downloads = (List<Download>) response.getEntity();
 

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -151,9 +151,7 @@ public class UserResourceTest {
 		List<Download> downloads;
 
 		// Get the initial state of the downloads - may not be empty
-		// It appears queryOffset cannot be empty!
-		String queryOffset = "1 = 1";
-		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
+		response = userResource.getDownloads(facilityName, sessionId, null);
 		assertEquals(200, response.getStatus());
 
 		downloads = (List<Download>) response.getEntity();
@@ -183,7 +181,7 @@ public class UserResourceTest {
 		assertTrue(downloadId > 0);
 
 		// Now, there should be one download, whose downloadId matches
-		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
+		response = userResource.getDownloads(facilityName, sessionId, null);
 		assertEquals(200, response.getStatus());
 
 		// Doesn't parse as JSON, try a direct cast
@@ -224,7 +222,7 @@ public class UserResourceTest {
 
 		// and test that the new status has been set
 
-		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
+		response = userResource.getDownloads(facilityName, sessionId, null);
 		assertEquals(200, response.getStatus());
 		downloads = (List<Download>) response.getEntity();
 
@@ -242,7 +240,7 @@ public class UserResourceTest {
 		// and check that it has worked (again, not bothering to check that nothing else
 		// has changed)
 
-		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
+		response = userResource.getDownloads(facilityName, sessionId, null);
 		assertEquals(200, response.getStatus());
 		downloads = (List<Download>) response.getEntity();
 


### PR DESCRIPTION
- Jobs without preparedIds to be marked RESTORING get marked PREPARING instead, so that they get assigned one (preparedId) by the usual status checks.

Closes #40 