### PR TITLE
 Block user from starting queued downloads with set status #42 

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: payara6
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 
 import org.icatproject.topcat.httpclient.*;
 import org.icatproject.topcat.exceptions.*;
+import org.apache.commons.lang3.StringUtils;
 import org.icatproject.topcat.domain.*;
 
 import jakarta.json.*;
@@ -91,6 +92,33 @@ public class IcatClient {
     	} catch (Exception e){
             throw new BadRequestException(e.getMessage());
     	}
+	}
+
+	/**
+	 * Gets a single Entity of the specified type, without any other conditions.
+	 * 
+	 * @param entityType Type of ICAT Entity to get
+	 * @return A single ICAT Entity of the specified type as a JsonObject
+	 * @throws TopcatException
+	 */
+	public JsonObject getEntity(String entityType) throws TopcatException {
+		try {
+			String entityCapital = StringUtils.capitalize(entityType.toLowerCase());
+			String query = URLEncoder.encode("SELECT o FROM " + entityCapital + " o LIMIT 0, 1", "UTF8");
+			String url = "entityManager?sessionId="  + URLEncoder.encode(sessionId, "UTF8") + "&query=" + query;
+			Response response = httpClient.get(url, new HashMap<String, String>());
+			if(response.getCode() == 404){
+				throw new NotFoundException("Could not run getEntity got a 404 response");
+			} else if(response.getCode() >= 400){
+				throw new BadRequestException(Utils.parseJsonObject(response.toString()).getString("message"));
+			}
+			JsonObject entity = Utils.parseJsonArray(response.toString()).getJsonObject(0);
+			return entity.getJsonObject(entityCapital);
+		} catch (TopcatException e){
+			throw e;
+		} catch (Exception e) {
+			throw new BadRequestException(e.getMessage());
+		}
 	}
 
 	public List<JsonObject> getEntities(String entityType, List<Long> entityIds) throws TopcatException {

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -260,6 +260,9 @@ public class UserResource {
 		if (!download.getUserName().equals(cartUserName)) {
 			throw new ForbiddenException("you do not have permission to delete this download");
 		}
+        if (download.getPreparedId() == null && download.getStatus().equals(DownloadStatus.PAUSED)) {
+            throw new ForbiddenException("Cannot modify status of a queued download");
+        }
 
         download.setStatus(DownloadStatus.valueOf(value));
         if(value.equals("COMPLETE")){

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -88,10 +88,9 @@ public class UserResourceTest {
 	public void testGetSize() throws Exception {
 		String facilityName = "LILS";
 		String entityType = "investigation";
-		Long entityId = (long) 1;
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
-
-		List<Long> emptyIds = new ArrayList<Long>();
+		JsonObject investigation = icatClient.getEntity(entityType);
+		long entityId = investigation.getInt("id");
 
 		Response response = userResource.getSize(facilityName, sessionId, entityType, entityId);
 
@@ -105,6 +104,9 @@ public class UserResourceTest {
 	@Test
 	public void testCart() throws Exception {
 		String facilityName = "LILS";
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonObject dataset = icatClient.getEntity("dataset");
+		long entityId = dataset.getInt("id");
 
 		Response response;
 
@@ -127,7 +129,7 @@ public class UserResourceTest {
 		// We assume that there is a dataset with id = 1, and that simple/root can see
 		// it.
 
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
+		response = userResource.addCartItems(facilityName, sessionId, "dataset " + entityId, false);
 		assertEquals(200, response.getStatus());
 
 		response = userResource.getCart(facilityName, sessionId);
@@ -138,7 +140,7 @@ public class UserResourceTest {
 		// Again, this ought to be done directly, rather than using the methods we
 		// should be testing independently!
 
-		response = userResource.deleteCartItems(facilityName, sessionId, "dataset 1");
+		response = userResource.deleteCartItems(facilityName, sessionId, "dataset " + entityId);
 		assertEquals(200, response.getStatus());
 		assertEquals(0, getCartSize(response));
 	}
@@ -149,6 +151,9 @@ public class UserResourceTest {
 		Response response;
 		JsonObject json;
 		List<Download> downloads;
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonObject dataset = icatClient.getEntity("dataset");
+		long entityId = dataset.getInt("id");
 
 		// Get the initial state of the downloads - may not be empty
 		// It appears queryOffset cannot be empty!
@@ -163,7 +168,7 @@ public class UserResourceTest {
 		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize);
 
 		// Put something into the Cart, so we have something to submit
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
+		response = userResource.addCartItems(facilityName, sessionId, "dataset " + entityId, false);
 		assertEquals(200, response.getStatus());
 
 		// Now submit it
@@ -318,7 +323,7 @@ public class UserResourceTest {
 	private Download findDownload(List<Download> downloads, Long downloadId) {
 
 		for (Download download : downloads) {
-			if (download.getId() == downloadId)
+			if (download.getId().equals(downloadId))
 				return download;
 		}
 		return null;

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -4,6 +4,7 @@ facility.LILS.icatUrl = https://localhost:8181
 facility.LILS.idsUrl = https://localhost:8181
 adminUserNames=simple/root
 anonUserName=anon/anon
+ids.timeout=10s
 
 # Disable scheduled Download status checks (DO THIS FOR TESTS ONLY!)
 test.disableDownloadStatusChecks = true


### PR DESCRIPTION
- If a user tries to set the status of a job without a preparedId in the PAUSED status (i.e. a large one that has been queued) it will raise a 403 and leave the status unchanged

Merged in changed from #39 to get the `Long.equals` check in `UserResourceTest`, which the new test relies on.

Closes #42