### PR TITLE
Poll and prepare queued Downloads #38

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: payara6
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 

--- a/pom.xml
+++ b/pom.xml
@@ -244,12 +244,6 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>2.19.1</version>
 						<configuration>
-							<excludes>
-								<!-- Requires an arquillian-persistence implementation compatible with the jakarta namespace. -->
-								<exclude>**/StatusCheckTest.java</exclude>
-							</excludes>
-							<!-- TODO remove next line -->
-							<!-- <skipTests>true</skipTests> -->
 							<argLine>-Xmx768m -XX:MaxMetaspaceSize=256m</argLine>
 							<systemPropertyVariables>
 								<java.util.logging.config.file>

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -84,3 +84,8 @@ maxCacheSize=100000
 
 # Username that corresponds with the anonymous user - this is used to make anonymous carts unique
 anonUserName=anon/anon
+
+# Limit the number maximum of active RESTORING downloads. Does not affect user submitted carts,
+# but queued requests will only be started when there are less than this many RESTORING downloads.
+# Negative values will start all queued jobs immediately, regardless of load.
+queue.maxActiveDownloads = 10

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 
 import org.icatproject.topcat.httpclient.*;
 import org.icatproject.topcat.exceptions.*;
+import org.apache.commons.lang3.StringUtils;
 import org.icatproject.topcat.domain.*;
 
 import jakarta.json.*;
@@ -91,6 +92,33 @@ public class IcatClient {
     	} catch (Exception e){
             throw new BadRequestException(e.getMessage());
     	}
+	}
+
+	/**
+	 * Gets a single Entity of the specified type, without any other conditions.
+	 * 
+	 * @param entityType Type of ICAT Entity to get
+	 * @return A single ICAT Entity of the specified type as a JsonObject
+	 * @throws TopcatException
+	 */
+	public JsonObject getEntity(String entityType) throws TopcatException {
+		try {
+			String entityCapital = StringUtils.capitalize(entityType.toLowerCase());
+			String query = URLEncoder.encode("SELECT o FROM " + entityCapital + " o LIMIT 0, 1", "UTF8");
+			String url = "entityManager?sessionId="  + URLEncoder.encode(sessionId, "UTF8") + "&query=" + query;
+			Response response = httpClient.get(url, new HashMap<String, String>());
+			if(response.getCode() == 404){
+				throw new NotFoundException("Could not run getEntity got a 404 response");
+			} else if(response.getCode() >= 400){
+				throw new BadRequestException(Utils.parseJsonObject(response.toString()).getString("message"));
+			}
+			JsonObject entity = Utils.parseJsonArray(response.toString()).getJsonObject(0);
+			return entity.getJsonObject(entityCapital);
+		} catch (TopcatException e){
+			throw e;
+		} catch (Exception e) {
+			throw new BadRequestException(e.getMessage());
+		}
 	}
 
 	public List<JsonObject> getEntities(String entityType, List<Long> entityIds) throws TopcatException {

--- a/src/main/java/org/icatproject/topcat/StatusCheck.java
+++ b/src/main/java/org/icatproject/topcat/StatusCheck.java
@@ -57,13 +57,14 @@ public class StatusCheck {
   @Resource(name = "mail/topcat")
   private Session mailSession;
   
-  @Schedule(hour="*", minute="*", second="*")
+  @Schedule(hour = "*", minute = "*", second = "*")
   private void poll() {
 	  
-	  // Observation: glassfish may already prevent multiple executions, and may even count the attempt as an error,
-	  // so it is possible that the use of a semaphore here is redundant.
+    // Observation: glassfish may already prevent multiple executions, and may even
+    // count the attempt as an error, so it is possible that the use of a semaphore
+    // here is redundant.
 	  
-    if(!busy.compareAndSet(false, true)){
+    if (!busy.compareAndSet(false, true)) {
       return;
     }
 
@@ -71,14 +72,16 @@ public class StatusCheck {
       Properties properties = Properties.getInstance();
       int pollDelay = Integer.valueOf(properties.getProperty("poll.delay", "600"));
       int pollIntervalWait = Integer.valueOf(properties.getProperty("poll.interval.wait", "600"));
+      int maxActiveDownloads = Integer.valueOf(properties.getProperty("queue.maxActiveDownloads", "0"));
 
       // For testing, separate out the poll body into its own method
       // And allow test configurations to disable scheduled status checks
-      if( ! Boolean.valueOf(properties.getProperty("test.disableDownloadStatusChecks","false"))) {
+      if (!Boolean.valueOf(properties.getProperty("test.disableDownloadStatusChecks", "false"))) {
           updateStatuses(pollDelay, pollIntervalWait, null);   	  
+        startQueuedDownloads(maxActiveDownloads);
       }
       
-    } catch(Exception e){
+    } catch (Exception e) {
       logger.error(e.getMessage());
     } finally {
       busy.set(false);
@@ -88,39 +91,50 @@ public class StatusCheck {
   /**
    * Update the status of each relevant download.
    * 
-   * @param pollDelay minimum time to wait before initial preparation/check
-   * @param pollIntervalWait minimum time between checks
+   * @param pollDelay         minimum time to wait before initial
+   *                          preparation/check
+   * @param pollIntervalWait  minimum time between checks
    * @param injectedIdsClient optional (possibly mock) IdsClient
    * @throws Exception
    */
   public void updateStatuses(int pollDelay, int pollIntervalWait, IdsClient injectedIdsClient) throws Exception {
 	  
-	  // This method is intended for testing, but we are forced to make it public rather than protected.
+    // This method is intended for testing, but we are forced to make it public
+    // rather than protected.
 
-	  TypedQuery<Download> query = em.createQuery("select download from Download download where download.isDeleted != true and download.status != org.icatproject.topcat.domain.DownloadStatus.EXPIRED and (download.status = org.icatproject.topcat.domain.DownloadStatus.PREPARING or (download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING and download.transport in ('https','http')) or (download.email != null and download.isEmailSent = false))", Download.class);
+    String selectString = "select download from Download download where download.isDeleted != true";
+    String notExpiredCondition = "download.status != org.icatproject.topcat.domain.DownloadStatus.EXPIRED";
+    String preparingCondition = "download.status = org.icatproject.topcat.domain.DownloadStatus.PREPARING";
+    String restoringHttpCondition = "(download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING and download.transport in ('https','http'))";
+    String notEmailSentCondition = "(download.email != null and download.isEmailSent = false)";
+    String isActiveCondition = preparingCondition + " or " + restoringHttpCondition + " or " + notEmailSentCondition;
+    String queryString = selectString + " and " + notExpiredCondition + " and (" + isActiveCondition + ")";
+
+    TypedQuery<Download> query = em.createQuery(queryString, Download.class);
       List<Download> downloads = query.getResultList();
 
-      for(Download download : downloads){
+    for (Download download : downloads) {
         Date lastCheck = lastChecks.get(download.getId());
         Date now = new Date();
         long createdSecondsAgo = (now.getTime() - download.getCreatedAt().getTime()) / 1000;
-        if(download.getStatus() == DownloadStatus.PREPARING){
-        	// If prepareDownload was called previously but caught an exception (other than TopcatException),
-        	// we should not call it again immediately, but should impose a delay. See issue #462.          
-          if(lastCheck == null){
+      if (download.getStatus() == DownloadStatus.PREPARING) {
+        // If prepareDownload was called previously but caught an exception (other than
+        // TopcatException), we should not call it again immediately, but should impose
+        // a delay. See issue #462.
+        if (lastCheck == null) {
         	  prepareDownload(download, injectedIdsClient);
             } else {
               long lastCheckSecondsAgo = (now.getTime() - lastCheck.getTime()) / 1000;
-              if(lastCheckSecondsAgo >= pollIntervalWait){
+          if (lastCheckSecondsAgo >= pollIntervalWait) {
             	  prepareDownload(download, injectedIdsClient);
               }
             }
-        } else if(createdSecondsAgo >= pollDelay){
-          if(lastCheck == null){
+      } else if (createdSecondsAgo >= pollDelay) {
+        if (lastCheck == null) {
             performCheck(download, injectedIdsClient);
           } else {
             long lastCheckSecondsAgo = (now.getTime() - lastCheck.getTime()) / 1000;
-            if(lastCheckSecondsAgo >= pollIntervalWait){
+          if (lastCheckSecondsAgo >= pollIntervalWait) {
               performCheck(download, injectedIdsClient);
             }
           }
@@ -258,8 +272,42 @@ public class StatusCheck {
 
   }
   
+  /**
+   * Prepares Downloads which are queued (PAUSED with no preparedId) up to the maxActiveDownloads limit.
+   * 
+   * @param maxActiveDownloads Limit on the number of concurrent jobs with RESTORING status
+   * @throws Exception
+   */
+  private void startQueuedDownloads(int maxActiveDownloads) throws Exception {
+    if (maxActiveDownloads == 0) { return; }
+    String selectString = "select download from Download download where download.isDeleted != true";
+    String restoringCondition = "download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING";
+    String pausedCondition = "download.status = org.icatproject.topcat.domain.DownloadStatus.PAUSED";
+
+    String activeQueryString = selectString + " and " + restoringCondition;
+    TypedQuery<Download> activeDownloadsQuery = em.createQuery(activeQueryString, Download.class);
+    List<Download> activeDownloads = activeDownloadsQuery.getResultList();
+
+    String queuedQueryString = selectString + " and " + pausedCondition + " and download.preparedId == null";
+    if (maxActiveDownloads > 0) {
+      int freeActiveDownloads = maxActiveDownloads - activeDownloads.size();
+      if (freeActiveDownloads <= 0) {
+        return;
+      }
+      queuedQueryString += " order by download.createdAt limit " + Integer.toString(freeActiveDownloads);
+    }
+
+    TypedQuery<Download> queuedDownloadsQuery = em.createQuery(queuedQueryString, Download.class);
+    List<Download> queuedDownloads = queuedDownloadsQuery.getResultList();
+    
+    for (Download queuedDownload : queuedDownloads) {
+      queuedDownload.setStatus(DownloadStatus.PREPARING);
+      prepareDownload(queuedDownload, null);
+    }
+  }
+
   private void handleException( Download download, String reason, boolean doExpire ) {
-	  if( doExpire ) {
+    if( doExpire ) {
 	      logger.error("Marking download " + download.getId() + " as expired. Reason: " + reason);
 	      download.setStatus(DownloadStatus.EXPIRED);
 	      em.persist(download);

--- a/src/main/java/org/icatproject/topcat/StatusCheck.java
+++ b/src/main/java/org/icatproject/topcat/StatusCheck.java
@@ -278,8 +278,11 @@ public class StatusCheck {
    * @param maxActiveDownloads Limit on the number of concurrent jobs with RESTORING status
    * @throws Exception
    */
-  private void startQueuedDownloads(int maxActiveDownloads) throws Exception {
-    if (maxActiveDownloads == 0) { return; }
+  public void startQueuedDownloads(int maxActiveDownloads) throws Exception {
+    if (maxActiveDownloads == 0) {
+      return;
+    }
+
     String selectString = "select download from Download download where download.isDeleted != true";
     String restoringCondition = "download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING";
     String pausedCondition = "download.status = org.icatproject.topcat.domain.DownloadStatus.PAUSED";
@@ -288,7 +291,7 @@ public class StatusCheck {
     TypedQuery<Download> activeDownloadsQuery = em.createQuery(activeQueryString, Download.class);
     List<Download> activeDownloads = activeDownloadsQuery.getResultList();
 
-    String queuedQueryString = selectString + " and " + pausedCondition + " and download.preparedId == null";
+    String queuedQueryString = selectString + " and " + pausedCondition + " and download.preparedId = null";
     if (maxActiveDownloads > 0) {
       int freeActiveDownloads = maxActiveDownloads - activeDownloads.size();
       if (freeActiveDownloads <= 0) {

--- a/src/test/java/org/icatproject/topcat/StatusCheckTest.java
+++ b/src/test/java/org/icatproject/topcat/StatusCheckTest.java
@@ -1,12 +1,8 @@
 package org.icatproject.topcat;
 
 import java.util.*;
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
-import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -20,53 +16,46 @@ import static org.junit.Assert.*;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
 import jakarta.ejb.EJB;
 
 import org.icatproject.topcat.domain.*;
-import org.icatproject.topcat.exceptions.NotFoundException;
 import org.icatproject.topcat.exceptions.TopcatException;
 import org.icatproject.topcat.repository.DownloadRepository;
-import org.icatproject.topcat.StatusCheck;
-
-import java.sql.*;
 
 @RunWith(Arquillian.class)
 public class StatusCheckTest {
 
-	@PersistenceContext(unitName = "topcat")
-	EntityManager em;
-
 	@Deployment
 	public static JavaArchive createDeployment() {
 		return ShrinkWrap.create(JavaArchive.class)
-			.addClasses(StatusCheck.class, DownloadRepository.class, IdsClient.class)
-			.addPackages(true,"org.icatproject.topcat.domain","org.icatproject.topcat.exceptions")
-			.addAsResource("META-INF/persistence.xml")
-			.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+				.addClasses(StatusCheck.class, DownloadRepository.class, IdsClient.class)
+				.addPackages(true, "org.icatproject.topcat.domain", "org.icatproject.topcat.exceptions")
+				.addAsResource("META-INF/persistence.xml")
+				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
 	}
-	
+
 	// StatusCheck treats TopcatExceptions differently to all other Exceptions,
-	// so need to test both cases.  However, the only IdsClient method used by StatusCheck
-	// that can throw anything other than a TopcatException is isPrepared;
-	// so it will not make sense to use FailMode.EXCEPTION for prepareData or getSize.
-	
-	public enum FailMode { OK, EXCEPTION, TOPCAT_EXCEPTION };
-	
+	// so need to test both cases. However, the only IdsClient method used by
+	// StatusCheck that can throw anything other than a TopcatException is
+	// isPrepared; so it will not make sense to use FailMode.EXCEPTION for
+	// prepareData or getSize.
+
+	public enum FailMode {
+		OK, EXCEPTION, TOPCAT_EXCEPTION
+	};
+
 	private class MockIdsClient extends IdsClient {
-		
+
 		// Make size and preparedId available for tests
-		
+
 		public Long size = 26L;
 		public String preparedId = "DummyPreparedId";
-		
+
 		private boolean isPreparedValue;
 		private FailMode failMode;
 		private boolean prepareDataCalledFlag;
 		private boolean isPreparedCalledFlag;
-		
+
 		public MockIdsClient(String url) {
 			// We are forced to do this as IdsClient has no no-args constructor;
 			// This forces us to have the Properties defined, even though we won't use them.
@@ -76,53 +65,56 @@ public class StatusCheckTest {
 			prepareDataCalledFlag = false;
 			isPreparedCalledFlag = false;
 		}
-		
+
 		// Mock overrides
-		
-		public String prepareData(String sessionId, List<Long> investigationIds, List<Long> datasetIds, List<Long> datafileIds) throws TopcatException {
+
+		public String prepareData(String sessionId, List<Long> investigationIds, List<Long> datasetIds,
+				List<Long> datafileIds) throws TopcatException {
 			prepareDataCalledFlag = true;
-			if( failMode == FailMode.TOPCAT_EXCEPTION ) {
-				throw new TopcatException(500,"Deliberate TopcatException for testing");
+			if (failMode == FailMode.TOPCAT_EXCEPTION) {
+				throw new TopcatException(500, "Deliberate TopcatException for testing");
 			}
 			return preparedId;
 		}
-		
+
 		public boolean isPrepared(String preparedId) throws TopcatException, IOException {
-			// This is the only IdsClient method used by StatusCheck that can throw anything other than a TopcatException
+			// This is the only IdsClient method used by StatusCheck that can throw anything
+			// other than a TopcatException
 			isPreparedCalledFlag = true;
-			if( failMode == FailMode.TOPCAT_EXCEPTION ) {
-				throw new TopcatException(500,"Deliberate TopcatException for testing");
-			} else if( failMode == FailMode.EXCEPTION ) {
+			if (failMode == FailMode.TOPCAT_EXCEPTION) {
+				throw new TopcatException(500, "Deliberate TopcatException for testing");
+			} else if (failMode == FailMode.EXCEPTION) {
 				throw new IOException("Deliberate exception for testing");
 			}
 			return isPreparedValue;
 		}
 
-		public Long getSize(String sessionId, List<Long> investigationIds, List<Long> datasetIds, List<Long> datafileIds) throws TopcatException {
-			if( failMode == FailMode.TOPCAT_EXCEPTION ) {
-				throw new TopcatException(500,"Deliberate TopcatException for testing");
+		public Long getSize(String sessionId, List<Long> investigationIds, List<Long> datasetIds,
+				List<Long> datafileIds) throws TopcatException {
+			if (failMode == FailMode.TOPCAT_EXCEPTION) {
+				throw new TopcatException(500, "Deliberate TopcatException for testing");
 			}
 			return size;
 		}
-		
+
 		// Mock utility methods
-		
+
 		public void setIsPrepared(Boolean aBool) {
 			isPreparedValue = aBool;
 		}
-		
+
 		public void resetPrepareDataCalledFlag() {
 			prepareDataCalledFlag = false;
 		}
-		
+
 		public void resetIsPreparedCalledFlag() {
 			isPreparedCalledFlag = false;
 		}
-		
+
 		public void setFailMode(FailMode aFailMode) {
 			failMode = aFailMode;
 		}
-		
+
 		public boolean prepareDataWasCalled() {
 			return prepareDataCalledFlag;
 		}
@@ -137,691 +129,732 @@ public class StatusCheckTest {
 
 	@Inject
 	private StatusCheck statusCheck;
-	
+
 	@Test
 	@Transactional
 	public void testSimpleDownload() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId";
-		String transport = "http";
-		
-		// Create a single-tier download; initial status should be COMPLETE
-		Download dummyDownload = createDummyDownload(preparedId, transport, false);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.COMPLETE, dummyDownload.getStatus());
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
+			String preparedId = "InitialPreparedId";
+			String transport = "http";
 
-		/*
-		 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck timestamp for our test download,
-		 * which could prevent the test call below from doing any useful work.
-		 * We are not (yet) testing the delay behaviour, so together these imply that we should set very short wait times.
-		 * Of course, even 1 second is too long!
-		 */
-		
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// This download should have been ignored - no status change, no email sent.
-		// REMEMBER: dummyDownload.email is null, so it should be excluded by the query in updateStatuses()		
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
+			// Create a single-tier download; initial status should be COMPLETE
+			Download dummyDownload = createDummyDownload(preparedId, transport, false, false);
+			downloadId = dummyDownload.getId();
+
+			assertEquals(DownloadStatus.COMPLETE, dummyDownload.getStatus());
+
+			/*
+			 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck
+			 * timestamp for our test download, which could prevent the test call below from
+			 * doing any useful work. We are not (yet) testing the delay behaviour, so
+			 * together these imply that we should set very short wait times.
+			 * Of course, even 1 second is too long!
+			 */
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// This download should have been ignored - no status change, no email sent.
+			// REMEMBER: dummyDownload.email is null, so it should be excluded by the query
+			// in updateStatuses()
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
 	}
-	
+
 	@Test
 	@Transactional
 	public void testTwoTierDownload() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId2";
-		String transport = "http";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
 
-		/*
-		 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck timestamp for our test download,
-		 * which could prevent the test call below from doing any useful work.
-		 * We are not (yet) testing the delay behaviour, so together these imply that we should set very short wait times.
-		 * Of course, even 1 second is too long!
-		 * TODO: consider adding sleeps to test more realistic behaviour.
-		 */
-		
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be RESTORING, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now mock the IDS having prepared the data
-		
-		mockIdsClient.setIsPrepared(true);
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download should now be COMPLETE, and email flagged as sent (though it wasn't!)
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
-		assertTrue(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
+			String preparedId = "InitialPreparedId2";
+			String transport = "http";
+
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
+
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+
+			/*
+			 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck
+			 * timestamp for our test download, which could prevent the test call below from
+			 * doing any useful work. We are not (yet) testing the delay behaviour, so
+			 * together these imply that we should set very short wait times.
+			 * Of course, even 1 second is too long!
+			 * TODO: consider adding sleeps to test more realistic behaviour.
+			 */
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should now be RESTORING, no email sent.
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now mock the IDS having prepared the data
+
+			mockIdsClient.setIsPrepared(true);
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download should now be COMPLETE, and email flagged as sent (though it
+			// wasn't!)
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
+			assertTrue(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
 	}
-	
+
 	@Test
 	@Transactional
 	public void testTwoTierNonHttpDownload() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId2";
-		String transport = "globus";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+		Long downloadId = null;
+		Long completeDownloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
 
-		/*
-		 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck timestamp for our test download,
-		 * which could prevent the test call below from doing any useful work.
-		 * We are not (yet) testing the delay behaviour, so together these imply that we should set very short wait times.
-		 * Of course, even 1 second is too long!
-		 * TODO: consider adding sleeps to test more realistic behaviour.
-		 */
-		
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be RESTORING, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now mock the IDS having prepared the data
-		
-		mockIdsClient.setIsPrepared(true);
-		
-		// But as it's not an http[s] download, updateStatuses won't test this
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download still be RESTORING, and email still not sent
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Mock pollcat setting the status to COMPLETE
-		// It does this using the PUT <topcat>/admin/download/{id}/status API,
-		// which uses the DownloadRepository
-		
-		postDownload = downloadRepository.getDownload(downloadId);
-		postDownload.setStatus(DownloadStatus.COMPLETE);
-		postDownload.setCompletedAt(new Date());
+			String preparedId = "InitialPreparedId2";
+			String transport = "globus";
 
-		downloadRepository.save(postDownload);
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download still be RESTORING, but download.email is null, so isEmailSent should still be false
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+
+			/*
+			 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck
+			 * timestamp for our test download, which could prevent the test call below from
+			 * doing any useful work. We are not (yet) testing the delay behaviour, so
+			 * together these imply that we should set very short wait times.
+			 * Of course, even 1 second is too long!
+			 * TODO: consider adding sleeps to test more realistic behaviour.
+			 */
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should now be RESTORING, no email sent.
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now mock the IDS having prepared the data
+
+			mockIdsClient.setIsPrepared(true);
+
+			// But as it's not an http[s] download, updateStatuses won't test this
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download still be RESTORING, and email still not sent
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Mock pollcat setting the status to COMPLETE
+			// It does this using the PUT <topcat>/admin/download/{id}/status API,
+			// which uses the DownloadRepository
+
+			postDownload = downloadRepository.getDownload(downloadId);
+			postDownload.setStatus(DownloadStatus.COMPLETE);
+			postDownload.setCompletedAt(new Date());
+
+			// Note this creates a new Download with a different id
+			Download completeDownload = downloadRepository.save(postDownload);
+			completeDownloadId = completeDownload.getId();
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			postDownload = getDummyDownload(completeDownloadId);
+			assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+			deleteDummyDownload(completeDownloadId);
+		}
 	}
-	
+
 	@Test
 	@Transactional
 	public void testPrepareDataFailure() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId3";
-		String transport = "http";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
 
-		/*
-		 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck timestamp for our test download,
-		 * which could prevent the test call below from doing any useful work.
-		 * We are not (yet) testing the delay behaviour, so together these imply that we should set very short wait times.
-		 * Of course, even 1 second is too long!
-		 * TODO: consider adding sleeps to test more realistic behaviour.
-		 */
-		
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		// In this test, have the prepareData call fail.
-		// Note: IdsClient.prepareData() can only throw TopcatException;
-		// we cannot test handling of other exceptions using the mock.
-		
-		// A TopcatException - should expire the download
-		
-		mockIdsClient.setFailMode(FailMode.TOPCAT_EXCEPTION);
+			String preparedId = "InitialPreparedId3";
+			String transport = "http";
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be EXPIRED, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.EXPIRED, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
+
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+
+			/*
+			 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck
+			 * timestamp for our test download, which could prevent the test call below from
+			 * doing any useful work. We are not (yet) testing the delay behaviour, so
+			 * together these imply that we should set very short wait times.
+			 * Of course, even 1 second is too long!
+			 * TODO: consider adding sleeps to test more realistic behaviour.
+			 */
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			// In this test, have the prepareData call fail.
+			// Note: IdsClient.prepareData() can only throw TopcatException;
+			// we cannot test handling of other exceptions using the mock.
+
+			// A TopcatException - should expire the download
+
+			mockIdsClient.setFailMode(FailMode.TOPCAT_EXCEPTION);
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should now be EXPIRED, no email sent.
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.EXPIRED, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
 	}
 
 	@Test
 	@Transactional
 	public void testIsPreparedFailure() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId3";
-		String transport = "http";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
 
-		/*
-		 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck timestamp for our test download,
-		 * which could prevent the test call below from doing any useful work.
-		 * We are not (yet) testing the delay behaviour, so together these imply that we should set very short wait times.
-		 * Of course, even 1 second is too long!
-		 * TODO: consider adding sleeps to test more realistic behaviour.
-		 */
-		
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		// In this test, have the prepareData call succeed
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be RESTORING, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now mock the IDS failing
-		// First, with an arbitrary exception - download status should not change
-		
-		mockIdsClient.setFailMode(FailMode.EXCEPTION);
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should not have changed
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now fail with a TopcatException - download should be Expired
-		
-		mockIdsClient.setFailMode(FailMode.TOPCAT_EXCEPTION);
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download should now be EXPIRED
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.EXPIRED, postDownload.getStatus());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
+			String preparedId = "InitialPreparedId3";
+			String transport = "http";
+
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
+
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+
+			/*
+			 * If (as I suspect) the scheduled poll() is running, it might add a lastCheck
+			 * timestamp for our test download, which could prevent the test call below from
+			 * doing any useful work. We are not (yet) testing the delay behaviour, so
+			 * together these imply that we should set very short wait times.
+			 * Of course, even 1 second is too long!
+			 * TODO: consider adding sleeps to test more realistic behaviour.
+			 */
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			// In this test, have the prepareData call succeed
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should now be RESTORING, no email sent.
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now mock the IDS failing
+			// First, with an arbitrary exception - download status should not change
+
+			mockIdsClient.setFailMode(FailMode.EXCEPTION);
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should not have changed
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now fail with a TopcatException - download should be Expired
+
+			mockIdsClient.setFailMode(FailMode.TOPCAT_EXCEPTION);
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download should now be EXPIRED
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.EXPIRED, postDownload.getStatus());
+
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
 	}
 
 	@Test
 	@Transactional
 	public void testDelays() throws Exception {
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId4";
-		String transport = "http";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
 
-		/*
-		 * We assume that the scheduled poll() is not doing any work!
-		 */
-		
-		int pollDelay = 1;
-		int pollIntervalWait = 3;
-		
-		// FIRST mock-scheduled call - expect prepareData to be called, status set to RESTORING
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be RESTORING, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// SECOND mock-scheduled call - too early: expect isPrepared NOT to be called, and nothing changed
+			String preparedId = "InitialPreparedId4";
+			String transport = "http";
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertFalse(mockIdsClient.isPreparedWasCalled());
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now sleep for at least pollDelay seconds, and try again
-		
-		TimeUnit.SECONDS.sleep(pollDelay+1);
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
 
-		// THIRD mock-scheduled call, after pollDelay seconds - expect isPrepared called, but no changes
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertTrue(mockIdsClient.isPreparedWasCalled());
-		mockIdsClient.resetIsPreparedCalledFlag();
-		
-		// But the status should not have changed, as isPrepared will have returned false
+			/*
+			 * We assume that the scheduled poll() is not doing any work!
+			 */
 
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// FOURTH  mock-scheduled call, before pollIntervalWait seconds have passed: isPrepared should NOT be called
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+			int pollDelay = 1;
+			int pollIntervalWait = 3;
 
-		assertFalse(mockIdsClient.isPreparedWasCalled());
+			// FIRST mock-scheduled call - expect prepareData to be called, status set to
+			// RESTORING
 
-		// Now mock the IDS having prepared the data
-		
-		mockIdsClient.setIsPrepared(true);
-		
-		// Now wait for at least pollIntervalWaitSeconds, and try again
-		
-		TimeUnit.SECONDS.sleep(pollIntervalWait+1);
-		
-		// FIFTH  mock-scheduled call - expect isPrepared called, status changed to COMPLETE etc.
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertTrue(mockIdsClient.isPreparedWasCalled());
-		mockIdsClient.resetIsPreparedCalledFlag();
-		
-		// Download should now be COMPLETE, and email flagged as sent (though it wasn't!)
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
-		assertTrue(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
-	}
-	
-	@Test
-	@Transactional
-	public void testExpiredDownloadsIgnored() throws Exception {
+			// Download status should now be RESTORING, no email sent.
 
-		DownloadStatus status = DownloadStatus.EXPIRED;
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId";
-		String transport = "http";
-		
-		// Create a single-tier download; initial status should be COMPLETE
-		Download dummyDownload = createDummyDownload(preparedId, transport, false);
-		Long downloadId = dummyDownload.getId();
-		
-		// Set the status and persist it
-		
-		dummyDownload.setStatus(status);
-		em.persist(dummyDownload);
-		em.flush();
-		
-		// Not testing delays, so set to zero
+			Download postDownload = getDummyDownload(downloadId);
 
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// This download should have been ignored - no status change, no email sent.
-		
-		assertFalse(mockIdsClient.prepareDataWasCalled());
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(status, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
-	}
-	
-	@Test
-	@Transactional
-	public void testDeletedDownloadsIgnored() throws Exception {
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
 
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId";
-		String transport = "http";
-		
-		// Create a single-tier download; initial status should be COMPLETE
-		Download dummyDownload = createDummyDownload(preparedId, transport, false);
-		Long downloadId = dummyDownload.getId();
-		
-		// Set download deleted and persist it
-		
-		dummyDownload.setIsDeleted(true);
-		em.persist(dummyDownload);
-		em.flush();
-		
-		// Not testing delays, so set to zero
+			// SECOND mock-scheduled call - too early: expect isPrepared NOT to be called,
+			// and nothing changed
 
-		int pollDelay = 0;
-		int pollIntervalWait = 0;
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// This download should have been ignored - still deleted, no email sent.
-		
-		assertFalse(mockIdsClient.prepareDataWasCalled());
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertTrue(postDownload.getIsDeleted());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
-	}
-	
-	@Test
-	@Transactional
-	public void testExceptionDelays() throws Exception {
-		
-		// Similar to testDelays, but set MockIdsClient to throw an (IO)Exception when used by performCheck
-		
-		String dummyUrl = "DummyUrl";
-		MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
-		
-		String preparedId = "InitialPreparedId4";
-		String transport = "http";
-		
-		// Create a two-tier download; initial status should be PREPARING
-		Download dummyDownload = createDummyDownload(preparedId, transport, true);
-		Long downloadId = dummyDownload.getId();
-		
-		assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
 
-		/*
-		 * We assume that the scheduled poll() is not doing any work!
-		 */
-		
-		int pollDelay = 1;
-		int pollIntervalWait = 3;
-		
-		// FIRST mock-scheduled call - expect prepareData to be called, status set to RESTORING
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		// Download status should now be RESTORING, no email sent.
-		
-		Download postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now set mockIdsClient to throw an (IO)Exception when isPrepared is called
-		
-		mockIdsClient.setFailMode(FailMode.EXCEPTION);
-		
-		// SECOND mock-scheduled call - too early: expect isPrepared NOT to be called, and nothing changed
+			assertFalse(mockIdsClient.isPreparedWasCalled());
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertFalse(mockIdsClient.isPreparedWasCalled());
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now sleep for at least pollDelay seconds, and try again
-		
-		TimeUnit.SECONDS.sleep(pollDelay+1);
+			postDownload = getDummyDownload(downloadId);
 
-		// THIRD mock-scheduled call, after pollDelay seconds - expect isPrepared called, but no changes
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertTrue(mockIdsClient.isPreparedWasCalled());
-		mockIdsClient.resetIsPreparedCalledFlag();
-		
-		// But the status should not have changed, as isPrepared will have thrown an exception
+			// Now sleep for at least pollDelay seconds, and try again
 
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// FOURTH  mock-scheduled call, before pollIntervalWait seconds have passed: isPrepared should NOT be called
-		// (the exception handling should have set the timestamp)
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+			TimeUnit.SECONDS.sleep(pollDelay + 1);
 
-		assertFalse(mockIdsClient.isPreparedWasCalled());
+			// THIRD mock-scheduled call, after pollDelay seconds - expect isPrepared
+			// called, but no changes
 
-		// Now mock the IDS having prepared the data - but will still throw an exception
-		
-		mockIdsClient.setIsPrepared(true);
-		
-		// Now wait for at least pollIntervalWaitSeconds, and try again
-		
-		TimeUnit.SECONDS.sleep(pollIntervalWait+1);
-		
-		// FIFTH mock-scheduled call. Nothing should have changed, because an IOException was thrown
-		
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertTrue(mockIdsClient.isPreparedWasCalled());
-		mockIdsClient.resetIsPreparedCalledFlag();
-		
-		// But the status should not have changed, as isPrepared will have thrown an exception
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
 
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
-		assertFalse(postDownload.getIsEmailSent());
-		
-		// Now tell the client to stop throwing exceptions
-		
-		mockIdsClient.setFailMode(FailMode.OK);
-		
-		// Now wait for at least pollIntervalWaitSeconds, and try again
-		
-		TimeUnit.SECONDS.sleep(pollIntervalWait+1);
-		
-		// SIXTH  mock-scheduled call - expect isPrepared called, status changed to COMPLETE etc.
+			assertTrue(mockIdsClient.isPreparedWasCalled());
+			mockIdsClient.resetIsPreparedCalledFlag();
 
-		statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
-		
-		assertTrue(mockIdsClient.isPreparedWasCalled());
-		mockIdsClient.resetIsPreparedCalledFlag();
-		
-		// Download should now be COMPLETE, and email flagged as sent (though it wasn't!)
-		
-		postDownload = getDummyDownload(downloadId);
-		
-		assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
-		assertTrue(postDownload.getIsEmailSent());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
-	}
+			// But the status should not have changed, as isPrepared will have returned
+			// false
 
-	@Test
-	@Transactional
-	public void testStartQueuedDownloadsNegative() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		Method method = StatusCheck.class.getDeclaredMethod("startQueuedDownloads", int.class);
-		method.setAccessible(true);
+			postDownload = getDummyDownload(downloadId);
 
-		String transport = "http";
-		Download dummyDownload1 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED);
-		Download dummyDownload2 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED);
-		Long downloadId1 = dummyDownload1.getId();
-		Long downloadId2 = dummyDownload2.getId();
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
 
-		method.invoke(statusCheck, -1);
-		
-		// All Downloads should have been prepared
-		
-		Download postDownload1 = getDummyDownload(downloadId1);
-		Download postDownload2 = getDummyDownload(downloadId2);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload1.getStatus());
-		assertNotNull(postDownload1.getPreparedId());
-		assertEquals(DownloadStatus.RESTORING, postDownload2.getStatus());
-		assertNotNull(postDownload2.getPreparedId());
-		
-		// clean up
-		deleteDummyDownload(postDownload1);
-		deleteDummyDownload(postDownload2);
-	}
+			// FOURTH mock-scheduled call, before pollIntervalWait seconds have passed:
+			// isPrepared should NOT be called
 
-	@Test
-	@Transactional
-	public void testStartQueuedDownloadsZero() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		Method method = StatusCheck.class.getDeclaredMethod("startQueuedDownloads", int.class);
-		method.setAccessible(true);
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
 
-		String transport = "http";
-		Download dummyDownload = createDummyDownload(null, transport, true, DownloadStatus.PAUSED);
-		Long downloadId = dummyDownload.getId();
+			assertFalse(mockIdsClient.isPreparedWasCalled());
 
-		method.invoke(statusCheck, 0);
-		
-		// Download status should still be PAUSED, as we unqueued a max of 0 downloads
-		
-		Download postDownload = getDummyDownload(downloadId);
+			// Now mock the IDS having prepared the data
 
-		assertEquals(DownloadStatus.PAUSED, postDownload.getStatus());
-		assertNull(postDownload.getPreparedId());
-		
-		// clean up
-		deleteDummyDownload(postDownload);
-	}
+			mockIdsClient.setIsPrepared(true);
 
-	@Test
-	@Transactional
-	public void testStartQueuedDownloadsNonZero() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		Method method = StatusCheck.class.getDeclaredMethod("startQueuedDownloads", int.class);
-		method.setAccessible(true);
+			// Now wait for at least pollIntervalWaitSeconds, and try again
 
-		String transport = "http";
-		Download dummyDownload1 = createDummyDownload("preparedId", transport, true, DownloadStatus.RESTORING);
-		Download dummyDownload2 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED);
-		Long downloadId1 = dummyDownload1.getId();
-		Long downloadId2 = dummyDownload2.getId();
+			TimeUnit.SECONDS.sleep(pollIntervalWait + 1);
 
-		method.invoke(statusCheck, 1);
-		
-		// Should not schedule the second Download, as we already have 1 which is RESTORING
-		
-		Download postDownload1 = getDummyDownload(downloadId1);
-		Download postDownload2 = getDummyDownload(downloadId2);
-		
-		assertEquals(DownloadStatus.RESTORING, postDownload1.getStatus());
-		assertNotNull(postDownload1.getPreparedId());
-		assertEquals(DownloadStatus.PAUSED, postDownload2.getStatus());
-		assertNull(postDownload2.getPreparedId());
-		
-		// clean up
-		deleteDummyDownload(postDownload1);
-		deleteDummyDownload(postDownload2);
-	}
-	
-	private Download createDummyDownload(String preparedId, String transport, Boolean isTwoLevel) {
-		if(isTwoLevel){
-			return createDummyDownload(preparedId, transport, isTwoLevel, DownloadStatus.PREPARING);
-		} else {
-			return createDummyDownload(preparedId, transport, isTwoLevel, DownloadStatus.COMPLETE);
+			// FIFTH mock-scheduled call - expect isPrepared called, status changed to
+			// COMPLETE etc.
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertTrue(mockIdsClient.isPreparedWasCalled());
+			mockIdsClient.resetIsPreparedCalledFlag();
+
+			// Download should now be COMPLETE, and email flagged as sent (though it
+			// wasn't!)
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
+			assertTrue(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
 		}
 	}
 
-	private Download createDummyDownload(String preparedId, String transport, Boolean isTwoLevel, DownloadStatus downloadStatus) {
-		
+	@Test
+	@Transactional
+	public void testExpiredDownloadsIgnored() throws Exception {
+		Long downloadId = null;
+		try {
+			DownloadStatus status = DownloadStatus.EXPIRED;
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
+
+			String preparedId = "InitialPreparedId";
+			String transport = "http";
+
+			// Create a single-tier download; initial status should be COMPLETE
+			Download dummyDownload = createDummyDownload(preparedId, transport, false, status, false);
+			downloadId = dummyDownload.getId();
+
+			// Not testing delays, so set to zero
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// This download should have been ignored - no status change, no email sent.
+
+			assertFalse(mockIdsClient.prepareDataWasCalled());
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(status, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
+	}
+
+	@Test
+	@Transactional
+	public void testDeletedDownloadsIgnored() throws Exception {
+		Long downloadId = null;
+		try {
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
+
+			String preparedId = "InitialPreparedId";
+			String transport = "http";
+
+			// Create a single-tier download; initial status should be COMPLETE
+			Download dummyDownload = createDummyDownload(preparedId, transport, false, true);
+			downloadId = dummyDownload.getId();
+
+			// Not testing delays, so set to zero
+
+			int pollDelay = 0;
+			int pollIntervalWait = 0;
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// This download should have been ignored - still deleted, no email sent.
+
+			assertFalse(mockIdsClient.prepareDataWasCalled());
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertTrue(postDownload.getIsDeleted());
+			assertFalse(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
+	}
+
+	@Test
+	@Transactional
+	public void testExceptionDelays() throws Exception {
+		Long downloadId = null;
+		try {
+			// Similar to testDelays, but set MockIdsClient to throw an (IO)Exception when
+			// used by performCheck
+
+			String dummyUrl = "DummyUrl";
+			MockIdsClient mockIdsClient = new MockIdsClient(dummyUrl);
+
+			String preparedId = "InitialPreparedId4";
+			String transport = "http";
+
+			// Create a two-tier download; initial status should be PREPARING
+			Download dummyDownload = createDummyDownload(preparedId, transport, true, false);
+			downloadId = dummyDownload.getId();
+
+			assertEquals(DownloadStatus.PREPARING, dummyDownload.getStatus());
+
+			/*
+			 * We assume that the scheduled poll() is not doing any work!
+			 */
+
+			int pollDelay = 1;
+			int pollIntervalWait = 3;
+
+			// FIRST mock-scheduled call - expect prepareData to be called, status set to
+			// RESTORING
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			// Download status should now be RESTORING, no email sent.
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now set mockIdsClient to throw an (IO)Exception when isPrepared is called
+
+			mockIdsClient.setFailMode(FailMode.EXCEPTION);
+
+			// SECOND mock-scheduled call - too early: expect isPrepared NOT to be called,
+			// and nothing changed
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertFalse(mockIdsClient.isPreparedWasCalled());
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now sleep for at least pollDelay seconds, and try again
+
+			TimeUnit.SECONDS.sleep(pollDelay + 1);
+
+			// THIRD mock-scheduled call, after pollDelay seconds - expect isPrepared
+			// called, but no changes
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertTrue(mockIdsClient.isPreparedWasCalled());
+			mockIdsClient.resetIsPreparedCalledFlag();
+
+			// But the status should not have changed, as isPrepared will have thrown an
+			// exception
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// FOURTH mock-scheduled call, before pollIntervalWait seconds have passed:
+			// isPrepared should NOT be called
+			// (the exception handling should have set the timestamp)
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertFalse(mockIdsClient.isPreparedWasCalled());
+
+			// Now mock the IDS having prepared the data - but will still throw an exception
+
+			mockIdsClient.setIsPrepared(true);
+
+			// Now wait for at least pollIntervalWaitSeconds, and try again
+
+			TimeUnit.SECONDS.sleep(pollIntervalWait + 1);
+
+			// FIFTH mock-scheduled call. Nothing should have changed, because an
+			// IOException was thrown
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertTrue(mockIdsClient.isPreparedWasCalled());
+			mockIdsClient.resetIsPreparedCalledFlag();
+
+			// But the status should not have changed, as isPrepared will have thrown an
+			// exception
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload.getStatus());
+			assertFalse(postDownload.getIsEmailSent());
+
+			// Now tell the client to stop throwing exceptions
+
+			mockIdsClient.setFailMode(FailMode.OK);
+
+			// Now wait for at least pollIntervalWaitSeconds, and try again
+
+			TimeUnit.SECONDS.sleep(pollIntervalWait + 1);
+
+			// SIXTH mock-scheduled call - expect isPrepared called, status changed to
+			// COMPLETE etc.
+
+			statusCheck.updateStatuses(pollDelay, pollIntervalWait, mockIdsClient);
+
+			assertTrue(mockIdsClient.isPreparedWasCalled());
+			mockIdsClient.resetIsPreparedCalledFlag();
+
+			// Download should now be COMPLETE, and email flagged as sent (though it
+			// wasn't!)
+
+			postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.COMPLETE, postDownload.getStatus());
+			assertTrue(postDownload.getIsEmailSent());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
+	}
+
+	@Test
+	@Transactional
+	public void testStartQueuedDownloadsNegative() throws Exception {
+		Long downloadId1 = null;
+		Long downloadId2 = null;
+		try {
+			String transport = "http";
+			Download dummyDownload1 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED, false);
+			Download dummyDownload2 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED, false);
+			downloadId1 = dummyDownload1.getId();
+			downloadId2 = dummyDownload2.getId();
+
+			statusCheck.startQueuedDownloads(-1);
+
+			// All Downloads should have been prepared, but because they have dummy
+			// (non-UUID) sessionId when prepareData is called it will throw and then mark
+			// the Downloads as EXPIRED as part of the error handling. This is OK, as it
+			// still indicates startQueuedDownloads called prepareData
+
+			Download postDownload1 = getDummyDownload(downloadId1);
+			Download postDownload2 = getDummyDownload(downloadId2);
+
+			assertEquals(DownloadStatus.EXPIRED, postDownload1.getStatus());
+			assertNull(postDownload1.getPreparedId());
+			assertEquals(DownloadStatus.EXPIRED, postDownload2.getStatus());
+			assertNull(postDownload2.getPreparedId());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId1);
+			deleteDummyDownload(downloadId2);
+		}
+	}
+
+	@Test
+	@Transactional
+	public void testStartQueuedDownloadsZero() throws Exception {
+		Long downloadId = null;
+		try {
+			String transport = "http";
+			Download dummyDownload = createDummyDownload(null, transport, true, DownloadStatus.PAUSED, false);
+			downloadId = dummyDownload.getId();
+
+			statusCheck.startQueuedDownloads(0);
+
+			// Download status should still be PAUSED, as we unqueued a max of 0 downloads
+
+			Download postDownload = getDummyDownload(downloadId);
+
+			assertEquals(DownloadStatus.PAUSED, postDownload.getStatus());
+			assertNull(postDownload.getPreparedId());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId);
+		}
+	}
+
+	@Test
+	@Transactional
+	public void testStartQueuedDownloadsNonZero() throws Exception {
+		Long downloadId1 = null;
+		Long downloadId2 = null;
+		try {
+			String transport = "http";
+			Download dummyDownload1 = createDummyDownload("preparedId", transport, true, DownloadStatus.RESTORING,
+					false);
+			Download dummyDownload2 = createDummyDownload(null, transport, true, DownloadStatus.PAUSED, false);
+			downloadId1 = dummyDownload1.getId();
+			downloadId2 = dummyDownload2.getId();
+
+			statusCheck.startQueuedDownloads(1);
+
+			// Should not schedule the second Download, as we already have 1 which is
+			// RESTORING
+
+			Download postDownload1 = getDummyDownload(downloadId1);
+			Download postDownload2 = getDummyDownload(downloadId2);
+
+			assertEquals(DownloadStatus.RESTORING, postDownload1.getStatus());
+			assertNotNull("Expected RESTORING Download to still have preparedId set", postDownload1.getPreparedId());
+			assertEquals(DownloadStatus.PAUSED, postDownload2.getStatus());
+			assertNull("Expected PAUSED Download to now have preparedId set", postDownload2.getPreparedId());
+		} finally {
+			// clean up
+			deleteDummyDownload(downloadId1);
+			deleteDummyDownload(downloadId2);
+		}
+	}
+
+	private Download createDummyDownload(String preparedId, String transport, Boolean isTwoLevel, Boolean isDeleted) {
+		if (isTwoLevel) {
+			return createDummyDownload(preparedId, transport, isTwoLevel, DownloadStatus.PREPARING, isDeleted);
+		} else {
+			return createDummyDownload(preparedId, transport, isTwoLevel, DownloadStatus.COMPLETE, isDeleted);
+		}
+	}
+
+	private Download createDummyDownload(String preparedId, String transport, Boolean isTwoLevel,
+			DownloadStatus downloadStatus, Boolean isDeleted) {
+
 		// This mocks what UserResource.submitCart() might do.
-		
+
 		String facilityName = "LILS";
 		String sessionId = "DummySessionId";
 		String fileName = "DummyFilename";
 		String userName = "DummyUsername";
 		String fullName = "Dummy Full Name";
-		// Note: setting email to null means we won't exercise (or test!) the mail-sending code
+		// Note: setting email to null means we won't exercise (or test!) the
+		// mail-sending code
 		String email = null;
-		
+
 		Download download = new Download();
 		download.setSessionId(sessionId);
 		download.setFacilityName(facilityName);
@@ -832,14 +865,14 @@ public class StatusCheckTest {
 		download.setEmail(email);
 		download.setIsEmailSent(false);
 		download.setSize(0);
-
-	        // Create one or more dummy DownloadItems
+		download.setIsDeleted(isDeleted);
+		download.setPreparedId(preparedId);
 
 		List<DownloadItem> downloadItems = new ArrayList<DownloadItem>();
 
-		for (int i=0; i <= 2; i++) {
+		for (int i = 0; i <= 2; i++) {
 			DownloadItem downloadItem = new DownloadItem();
-			downloadItem.setEntityId( 10L + i );
+			downloadItem.setEntityId(10L + i);
 			downloadItem.setEntityType(EntityType.dataset);
 			downloadItem.setDownload(download);
 			downloadItems.add(downloadItem);
@@ -849,37 +882,26 @@ public class StatusCheckTest {
 
 		download.setIsTwoLevel(isTwoLevel);
 
-		if(isTwoLevel){
+		if (isTwoLevel) {
 			download.setStatus(downloadStatus);
 		} else {
-	   		download.setPreparedId(preparedId);
 			download.setStatus(downloadStatus);
 		}
 
-		em.persist(download);
-		em.flush();
-		em.refresh(download);
-		em.flush();
+		return downloadRepository.save(download);
+	}
 
-	    return download;
-	}
-	
 	private Download getDummyDownload(Long downloadId) {
-		
-		Download download;
-		
-	    TypedQuery<Download> query = em.createQuery("select download from Download download where download.id = :id", Download.class);
-	    query.setParameter("id",downloadId);
-	    try {
-	    	download = query.getSingleResult();
-	    } catch (Exception e) {
-	    	download = null;
-	    }
-	    return download;
+		try {
+			return downloadRepository.getDownload(downloadId);
+		} catch (Exception e) {
+			return null;
+		}
 	}
-	
-	private void deleteDummyDownload(Download download) {
-		em.remove(download);;
-		em.flush();
+
+	private void deleteDummyDownload(Long downloadId) {
+		if (downloadId != null) {
+			downloadRepository.removeDownload(downloadId);
+		}
 	}
 }

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -88,10 +88,9 @@ public class UserResourceTest {
 	public void testGetSize() throws Exception {
 		String facilityName = "LILS";
 		String entityType = "investigation";
-		Long entityId = (long) 1;
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
-
-		List<Long> emptyIds = new ArrayList<Long>();
+		JsonObject investigation = icatClient.getEntity(entityType);
+		long entityId = investigation.getInt("id");
 
 		Response response = userResource.getSize(facilityName, sessionId, entityType, entityId);
 
@@ -105,6 +104,9 @@ public class UserResourceTest {
 	@Test
 	public void testCart() throws Exception {
 		String facilityName = "LILS";
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonObject dataset = icatClient.getEntity("dataset");
+		long entityId = dataset.getInt("id");
 
 		Response response;
 
@@ -127,7 +129,7 @@ public class UserResourceTest {
 		// We assume that there is a dataset with id = 1, and that simple/root can see
 		// it.
 
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
+		response = userResource.addCartItems(facilityName, sessionId, "dataset " + entityId, false);
 		assertEquals(200, response.getStatus());
 
 		response = userResource.getCart(facilityName, sessionId);
@@ -138,7 +140,7 @@ public class UserResourceTest {
 		// Again, this ought to be done directly, rather than using the methods we
 		// should be testing independently!
 
-		response = userResource.deleteCartItems(facilityName, sessionId, "dataset 1");
+		response = userResource.deleteCartItems(facilityName, sessionId, "dataset " + entityId);
 		assertEquals(200, response.getStatus());
 		assertEquals(0, getCartSize(response));
 	}
@@ -149,6 +151,9 @@ public class UserResourceTest {
 		Response response;
 		JsonObject json;
 		List<Download> downloads;
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonObject dataset = icatClient.getEntity("dataset");
+		long entityId = dataset.getInt("id");
 
 		// Get the initial state of the downloads - may not be empty
 		// It appears queryOffset cannot be empty!
@@ -163,7 +168,7 @@ public class UserResourceTest {
 		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize);
 
 		// Put something into the Cart, so we have something to submit
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
+		response = userResource.addCartItems(facilityName, sessionId, "dataset " + entityId, false);
 		assertEquals(200, response.getStatus());
 
 		// Now submit it
@@ -318,7 +323,7 @@ public class UserResourceTest {
 	private Download findDownload(List<Download> downloads, Long downloadId) {
 
 		for (Download download : downloads) {
-			if (download.getId() == downloadId)
+			if (download.getId().equals(downloadId))
 				return download;
 		}
 		return null;

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -4,6 +4,7 @@ facility.LILS.icatUrl = https://localhost:8181
 facility.LILS.idsUrl = https://localhost:8181
 adminUserNames=simple/root
 anonUserName=anon/anon
+ids.timeout=10s
 
 # Disable scheduled Download status checks (DO THIS FOR TESTS ONLY!)
 test.disableDownloadStatusChecks = true


### PR DESCRIPTION
Branched from #39 due to those test failures breaking the tests added as part of this PR.

- Add run.properties setting for the maximum number queued jobs to schedule concurrently
- After existing `updateStatuses` check, `startQueuedDownloads` up to the limit above minus any RESTORING Downloads
- Refactor existing query in `updateStatuses` for clarity
- Re-enabled `StatusCheckTest` in pom.xml
- Removed references to `em` in `StatusCheckTest` and use the `downloadRepository` instead, like the other tests
  - Mostly this did not require changes to any test logic, just the utility functions, but did alter updates to Downloads in the tests to either create with those values in the first place or explicitly create new Downloads
- Tests in `StatusCheckTest` now use `finally` to remove Downloads created for the test, as failure in one test meant bad data caused subsequent tests to fail
- Changes to how the dummy Downloads are created to support arbitrary preparedIds and statuses, for testing the new functions
- Whitespace changes caused by auto-formatting my changes (tried to limit this to only functions relevant to this change)

Closes #38 