### PR TITLE
Implement endpoint for queuing visits #48

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -84,3 +84,8 @@ maxCacheSize=100000
 
 # Username that corresponds with the anonymous user - this is used to make anonymous carts unique
 anonUserName=anon/anon
+
+# Limit the number files per queued Download part. Multiple Datasets will be combined into part
+# Downloads based on their fileCount up to this limit. If a single Dataset has a fileCount
+# greater than this limit, it will still be submitted in a part by itself.
+queue.maxFileCount = 10000

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -133,7 +133,7 @@ public class IcatClient {
 			String url = "entityManager?sessionId=" + URLEncoder.encode(sessionId, "UTF8") + "&query=" + encodedQuery;
 			Response response = httpClient.get(url, new HashMap<String, String>());
 			if (response.getCode() == 404) {
-				throw new NotFoundException("Could not run getEntities got a 404 response");
+				throw new NotFoundException("Could not run getDatasets got a 404 response");
 			} else if (response.getCode() >= 400) {
 				throw new BadRequestException(Utils.parseJsonObject(response.toString()).getString("message"));
 			}
@@ -162,7 +162,7 @@ public class IcatClient {
 			String url = "entityManager?sessionId=" + URLEncoder.encode(sessionId, "UTF8") + "&query=" + encodedQuery;
 			Response response = httpClient.get(url, new HashMap<String, String>());
 			if (response.getCode() == 404) {
-				throw new NotFoundException("Could not run getEntities got a 404 response");
+				throw new NotFoundException("Could not run getDatasetFileCount got a 404 response");
 			} else if (response.getCode() >= 400) {
 				throw new BadRequestException(Utils.parseJsonObject(response.toString()).getString("message"));
 			}

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -62,6 +62,7 @@ public class UserResource {
 	private CacheRepository cacheRepository;
 
 	private String anonUserName;
+	private long queueMaxFileCount;
 
 	@PersistenceContext(unitName = "topcat")
 	EntityManager em;
@@ -69,6 +70,7 @@ public class UserResource {
 	public UserResource() {
 		Properties properties = Properties.getInstance();
 		this.anonUserName = properties.getProperty("anonUserName", "");
+		this.queueMaxFileCount = Long.valueOf(properties.getProperty("queue.maxFileCount", "10000"));
     }
 
 	/**
@@ -665,9 +667,7 @@ public class UserResource {
 			throw new BadRequestException("fileName is required");
 		}
 
-		if (transport == null || transport.trim().isEmpty()) {
-			throw new BadRequestException("transport is required");
-		}
+		validateTransport(transport);
 
 		String icatUrl = getIcatUrl( facilityName );
 		IcatClient icatClient = new IcatClient(icatUrl, sessionId);
@@ -685,50 +685,21 @@ public class UserResource {
 		if(email != null && email.equals("")){
 			email = null;
 		}
-		
+
 
 		if (cart != null) {
 			em.refresh(cart);
-			
-			Download download = new Download();
-			download.setSessionId(sessionId);
-			download.setFacilityName(cart.getFacilityName());
-			download.setFileName(fileName);
-			download.setUserName(cart.getUserName());
-			download.setFullName(fullName);
-			download.setTransport(transport);
-			download.setEmail(email);
-			download.setIsEmailSent(false);
-			download.setSize(0);
-
+			Download download = createDownload(sessionId, cart.getFacilityName(), fileName, cart.getUserName(),
+					fullName, transport, email);
 			List<DownloadItem> downloadItems = new ArrayList<DownloadItem>();
-
 			for (CartItem cartItem : cart.getCartItems()) {
-				DownloadItem downloadItem = new DownloadItem();
-				downloadItem.setEntityId(cartItem.getEntityId());
-				downloadItem.setEntityType(cartItem.getEntityType());
-				downloadItem.setDownload(download);
+				DownloadItem downloadItem = createDownloadItem(download, cartItem.getEntityId(),
+						cartItem.getEntityType());
 				downloadItems.add(downloadItem);
 			}
-
 			download.setDownloadItems(downloadItems);
-
-			Boolean isTwoLevel = idsClient.isTwoLevel();
-			download.setIsTwoLevel(isTwoLevel);
-
-			if(isTwoLevel){
-				download.setStatus(DownloadStatus.PREPARING);
-			} else {
-				String preparedId = idsClient.prepareData(download.getSessionId(), download.getInvestigationIds(), download.getDatasetIds(), download.getDatafileIds());
-      			download.setPreparedId(preparedId);
-				download.setStatus(DownloadStatus.COMPLETE);
-			}
-
+			downloadId = submitDownload(idsClient, download, DownloadStatus.PREPARING);
 			try {
-				em.persist(download);
-				em.flush();
-				em.refresh(download);
-				downloadId = download.getId();
 				em.remove(cart);
 				em.flush();
 			} catch (Exception e) {
@@ -740,7 +711,191 @@ public class UserResource {
 		return emptyCart(facilityName, cartUserName, downloadId);
 	}
 
+	/**
+	 * Create a new Download object and set basic fields, excluding data and status.
+	 * 
+	 * @param sessionId    ICAT sessionId
+	 * @param facilityName ICAT Facility.name
+	 * @param fileName     Filename for the resultant Download
+	 * @param userName     ICAT User.name
+	 * @param fullName     ICAT User.fullName
+	 * @param transport    Transport mechanism to use
+	 * @param email        Optional email to send notification to on completion
+	 * @return Download object with basic fields set
+	 */
+	private static Download createDownload(String sessionId, String facilityName, String fileName, String userName,
+			String fullName, String transport, String email) {
+		Download download = new Download();
+		download.setSessionId(sessionId);
+		download.setFacilityName(facilityName);
+		download.setFileName(fileName);
+		download.setUserName(userName);
+		download.setFullName(fullName);
+		download.setTransport(transport);
+		download.setEmail(email);
+		download.setIsEmailSent(false);
+		download.setSize(0);
+		return download;
+	}
 
+	/**
+	 * Create a new DownloadItem.
+	 * 
+	 * @param download   Parent Download
+	 * @param entityId   ICAT Entity.id
+	 * @param entityType EntityType
+	 * @return DownloadItem with fields set
+	 */
+	private static DownloadItem createDownloadItem(Download download, long entityId, EntityType entityType) {
+		DownloadItem downloadItem = new DownloadItem();
+		downloadItem.setEntityId(entityId);
+		downloadItem.setEntityType(entityType);
+		downloadItem.setDownload(download);
+		return downloadItem;
+	}
+
+	/**
+	 * Set the final fields and persist a new Download request.
+	 * 
+	 * @param idsClient      Client for the IDS to use for the Download
+	 * @param download       Download to submit
+	 * @param downloadStatus Initial DownloadStatus to set iff the IDS isTwoLevel
+	 * @return Id of the new Download
+	 * @throws TopcatException
+	 */
+	private long submitDownload(IdsClient idsClient, Download download, DownloadStatus downloadStatus)
+			throws TopcatException {
+		Boolean isTwoLevel = idsClient.isTwoLevel();
+		download.setIsTwoLevel(isTwoLevel);
+
+		if (isTwoLevel) {
+			download.setStatus(downloadStatus);
+		} else {
+			String preparedId = idsClient.prepareData(download.getSessionId(), download.getInvestigationIds(),
+					download.getDatasetIds(), download.getDatafileIds());
+			download.setPreparedId(preparedId);
+			download.setStatus(DownloadStatus.COMPLETE);
+		}
+
+		try {
+			em.persist(download);
+			em.flush();
+			em.refresh(download);
+			return download.getId();
+		} catch (Exception e) {
+			logger.info("submitCart: exception during EntityManager operations: " + e.getMessage());
+			throw new BadRequestException("Unable to submit for cart for download");
+		}
+	}
+
+	/**
+	 * Queue and entire visit for download, split by Dataset into part Downloads if
+	 * needed.
+	 * 
+	 * @param facilityName ICAT Facility.name
+	 * @param sessionId    ICAT sessionId
+	 * @param transport    Transport mechanism to use
+	 * @param email        Optional email to notify upon completion
+	 * @param visitId      ICAT Investigation.visitId to submit
+	 * @return Array of Download ids
+	 * @throws TopcatException
+	 */
+	@POST
+	@Path("/queue/{facilityName}/visit")
+	public Response queueVisitId(@PathParam("facilityName") String facilityName,
+			@FormParam("sessionId") String sessionId, @FormParam("transport") String transport,
+			@FormParam("email") String email, @FormParam("visitId") String visitId) throws TopcatException {
+
+		logger.info("queueVisitId called");
+		validateTransport(transport);
+
+		String icatUrl = getIcatUrl(facilityName);
+		IcatClient icatClient = new IcatClient(icatUrl, sessionId);
+		String transportUrl = getDownloadUrl(facilityName, transport);
+		IdsClient idsClient = new IdsClient(transportUrl);
+
+		// If we wanted to block the user, this is where we would do it
+		String userName = icatClient.getUserName();
+		String fullName = icatClient.getFullName();
+		JsonArray datasets = icatClient.getDatasets(visitId);
+
+		long downloadId;
+		JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
+
+		long part = 1;
+		long downloadFileCount = 0;
+		List<DownloadItem> downloadItems = new ArrayList<DownloadItem>();
+		String filename = formatQueuedFilename(facilityName, visitId, part);
+		Download download = createDownload(sessionId, facilityName, filename, userName, fullName, transport, email);
+
+		for (JsonValue dataset : datasets) {
+			JsonArray datasetArray = dataset.asJsonArray();
+			long datasetId = datasetArray.getJsonNumber(0).longValueExact();
+			long datasetFileCount = datasetArray.getJsonNumber(1).longValueExact();
+			if (datasetFileCount < 1) {
+				// Database triggers should set this, but check explicitly anyway
+				datasetFileCount = icatClient.getDatasetFileCount(datasetId);
+			}
+
+			if (downloadFileCount > 0 && downloadFileCount + datasetFileCount > queueMaxFileCount) {
+				download.setDownloadItems(downloadItems);
+				downloadId = submitDownload(idsClient, download, DownloadStatus.PAUSED);
+				jsonArrayBuilder.add(downloadId);
+
+				part += 1;
+				downloadFileCount = 0;
+				downloadItems = new ArrayList<DownloadItem>();
+				filename = formatQueuedFilename(facilityName, visitId, part);
+				download = createDownload(sessionId, facilityName, filename, userName, fullName, transport, email);
+			}
+
+			DownloadItem downloadItem = createDownloadItem(download, datasetId, EntityType.dataset);
+			downloadItems.add(downloadItem);
+			downloadFileCount += datasetFileCount;
+		}
+		download.setDownloadItems(downloadItems);
+		downloadId = submitDownload(idsClient, download, DownloadStatus.PAUSED);
+		jsonArrayBuilder.add(downloadId);
+
+		return Response.ok(jsonArrayBuilder.build()).build();
+	}
+
+	/**
+	 * Format the filename for a queued Download, possibly one part of many.
+	 * 
+	 * @param facilityName ICAT Facility.name
+	 * @param visitId      ICAT Investigation.visitId
+	 * @param part         1 indexed part of the overall request
+	 * @return Formatted filename
+	 */
+	private static String formatQueuedFilename(String facilityName, String visitId, long part) {
+		String partString = String.valueOf(part);
+		StringBuilder partBuilder = new StringBuilder();
+		while (partBuilder.length() + partString.length() < 4) {
+			partBuilder.append("0");
+		}
+		partBuilder.append(partString);
+
+		StringBuilder filenameBuilder = new StringBuilder();
+		filenameBuilder.append(facilityName);
+		filenameBuilder.append("_");
+		filenameBuilder.append(visitId);
+		filenameBuilder.append("_");
+		filenameBuilder.append(partBuilder);
+		return filenameBuilder.toString();
+	}
+
+	/**
+	 * Validate that the submitted transport mechanism is not null or empty.
+	 * 
+	 * @param transport Transport mechanism to use
+	 * @throws BadRequestException if null or empty
+	 */
+	private static void validateTransport(String transport) throws BadRequestException {
+		if (transport == null || transport.trim().isEmpty()) {
+			throw new BadRequestException("transport is required");
+		}
+	}
 
 	/**
 	 * Retrieves the total file size (in bytes) for any investigation, datasets or datafiles.

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -251,6 +251,43 @@ public class UserResourceTest {
 	}
 
 	@Test
+	public void testQueueVisitId() throws Exception {
+		List<Long> downloadIds = new ArrayList<>();
+		try {
+			String facilityName = "LILS";
+			String transport = "http";
+			String email = "";
+			String visitId = "Proposal 0 - 0 0";
+			Response response = userResource.queueVisitId(facilityName, sessionId, transport, email, visitId);
+			assertEquals(200, response.getStatus());
+	
+			JsonArray downloadIdsArray = Utils.parseJsonArray(response.getEntity().toString());
+			assertEquals(3, downloadIdsArray.size());
+			long part = 1;
+			for (JsonNumber downloadIdJson : downloadIdsArray.getValuesAs(JsonNumber.class)) {
+				long downloadId = downloadIdJson.longValueExact();
+				downloadIds.add(downloadId);
+				Download download = downloadRepository.getDownload(downloadId);
+				assertNull(download.getPreparedId());
+				assertEquals(DownloadStatus.PAUSED, download.getStatus());
+				assertEquals(0, download.getInvestigationIds().size());
+				assertEquals(1, download.getDatasetIds().size());
+				assertEquals(0, download.getDatafileIds().size());
+				assertEquals("LILS_Proposal 0 - 0 0_000" + part, download.getFileName());
+				assertEquals(transport, download.getTransport());
+				assertEquals("simple/root", download.getUserName());
+				assertEquals("simple/root", download.getFullName());
+				assertEquals("", download.getEmail());
+				part += 1;
+			}
+		} finally {
+			for (long downloadId : downloadIds) {
+				downloadRepository.removeDownload(downloadId);
+			}
+		}
+	}
+
+	@Test
 	public void testGetDownloadTypeStatus() throws Exception {
 
 		String facilityName = "LILS";

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -289,7 +289,7 @@ public class UserResourceTest {
 				assertEquals(0, download.getInvestigationIds().size());
 				assertEquals(1, download.getDatasetIds().size());
 				assertEquals(0, download.getDatafileIds().size());
-				assertEquals("LILS_Proposal 0 - 0 0_000" + part, download.getFileName());
+				assertEquals("LILS_Proposal 0 - 0 0_part_" + part + "_of_3", download.getFileName());
 				assertEquals(transport, download.getTransport());
 				assertEquals("simple/root", download.getUserName());
 				assertEquals("simple/root", download.getFullName());

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -7,3 +7,5 @@ anonUserName=anon/anon
 
 # Disable scheduled Download status checks (DO THIS FOR TESTS ONLY!)
 test.disableDownloadStatusChecks = true
+# Test data has 100 files per Dataset, set this to 100 to ensure coverage of the batching logic
+queue.maxFileCount = 100


### PR DESCRIPTION
- Added new visitId queue endpoint to UserResource
- Refactored code common to exist methods
- Added function to IcatClient to get Dataset ids and counts for the new endpoint
- Added function to calculate Dataset.fileCount in case triggers are not causing this to be populated (not sure why this was the case - is this only a feature of Oracle DBs like we have in prod?)
- Added setting to run.properties to limit the size of each Download part queued.

Closes #48 