### PR TITLE
Replace mysql:mysql-connector-java with com.mysql:mysql-connector-j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,9 +171,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-		    <groupId>mysql</groupId>
-		    <artifactId>mysql-connector-java</artifactId>
-		    <version>6.0.5</version>
+		    <groupId>com.mysql</groupId>
+		    <artifactId>mysql-connector-j</artifactId>
+		    <version>9.1.0</version>
 		    <scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bump the mysql connector used for tests to the latest version to fix multiple dependabot vulnerabilities.

Note that this is effectively a successor to #27, but as the groupId has changed from mysql to [com.mysql](https://github.com/mysql/mysql-connector-j?tab=readme-ov-file#as-a-maven-dependency), I don't think dependabot was able to rebase it?