### PR TITLE
Block anonUserName from submitting a cart

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -84,6 +84,8 @@ maxCacheSize=100000
 
 # Username that corresponds with the anonymous user - this is used to make anonymous carts unique
 anonUserName=anon/anon
+# If false, anonymous users will not be able to download via any method (queued or otherwise)
+anonDownloadEnabled=True
 
 # Authentication plugin to use if it is not specified in the login request
 defaultPlugin=simple

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.icatproject.topcat.IdsClient;
+import org.icatproject.topcat.PriorityMap;
 import org.icatproject.topcat.FacilityMap;
 import org.icatproject.topcat.IcatClient;
 import org.icatproject.topcat.Properties;
@@ -742,6 +743,8 @@ public class UserResource {
 		String icatUrl = getIcatUrl( facilityName );
 		IcatClient icatClient = new IcatClient(icatUrl, sessionId);
 		String userName = icatClient.getUserName();
+		PriorityMap priorityMap = PriorityMap.getInstance();
+		priorityMap.checkAnonDownloadEnabled(userName);
 		String cartUserName = getCartUserName(userName, sessionId);
 
 		logger.info("submitCart: get cart for user: " + cartUserName + ", facility: " + facilityName + "...");

--- a/src/test/java/org/icatproject/topcat/PriorityMapTest.java
+++ b/src/test/java/org/icatproject/topcat/PriorityMapTest.java
@@ -1,13 +1,17 @@
 package org.icatproject.topcat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
+import org.icatproject.topcat.exceptions.ForbiddenException;
 import org.icatproject.topcat.exceptions.InternalException;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 public class PriorityMapTest {
     @Test
@@ -58,5 +62,15 @@ public class PriorityMapTest {
         HashMap<Integer, String> mapping = priorityMap.getMapping();
         assertEquals(1, mapping.size());
         assertEquals(expected, mapping.get(1));
+    }
+
+    @Test
+    public void testCheckAnonDownloadEnabled() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        PriorityMap priorityMap = new PriorityMap();
+        Field field = PriorityMap.class.getDeclaredField("anonDownloadEnabled");
+        field.setAccessible(true);
+        field.setBoolean(priorityMap, false);
+        ThrowingRunnable runnable = () -> {priorityMap.checkAnonDownloadEnabled("anon/anon");};
+        assertThrows(ForbiddenException.class, runnable);
     }
 }

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -4,6 +4,7 @@ facility.LILS.icatUrl = https://localhost:8181
 facility.LILS.idsUrl = https://localhost:8181
 adminUserNames=simple/root
 anonUserName=anon/anon
+anonDownloadEnabled=True
 defaultPlugin=simple
 defaultFacilityName=LILS
 ids.timeout=10s


### PR DESCRIPTION
Currently only blocks `submitCart`. Queuing endpoints are effectively blocked by setting priority to 0. Can 403 on other endpoints if desirable.

Closes #62