### PR TITLE
Limit number of files that can be submitted, other bugfixes

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -108,7 +108,11 @@ queue.maxActiveDownloads = 10
 # Limit the number files per queued Download part. Multiple Datasets will be combined into part
 # Downloads based on their fileCount up to this limit. If a single Dataset has a fileCount
 # greater than this limit, it will still be submitted in a part by itself.
-queue.maxFileCount = 10000
+queue.visit.maxPartFileCount = 10000
+
+# Requests to the /queue/files endpoint will be rejected if they exceed this number of files
+# Any chunking should be done clientside
+queue.files.maxFileCount = 10000
 
 # When queueing Downloads a positive priority will allow a User to proceed.
 # Non-positive values will block that User from submitting a request to the queue.

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -1,7 +1,9 @@
 package org.icatproject.topcat;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.ArrayList;
@@ -20,6 +22,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IcatClient {
+
+	public class DatafilesResponse {
+		public final List<Long> ids = new ArrayList<>();
+		public final Set<String> missing = new HashSet<>();
+		public long totalSize = 0L;
+	}
 
 	private Logger logger = LoggerFactory.getLogger(IcatClient.class);
 
@@ -139,7 +147,7 @@ public class IcatClient {
 	 * @throws TopcatException
 	 */
 	public JsonArray getDatasets(String visitId) throws TopcatException {
-			String query = "SELECT dataset.id, dataset.fileCount from Dataset dataset";
+			String query = "SELECT dataset.id, dataset.fileCount, dataset.fileSize from Dataset dataset";
 			query += " WHERE dataset.investigation.visitId = '" + visitId + "' ORDER BY dataset.id";
 		return submitQuery(query);
 	}
@@ -153,45 +161,56 @@ public class IcatClient {
 	 * @throws TopcatException
 	 * @throws UnsupportedEncodingException 
 	 */
-	public List<Long> getDatafiles(List<String> files) throws TopcatException, UnsupportedEncodingException {
-		List<Long> datafileIds = new ArrayList<>();
+	public DatafilesResponse getDatafiles(List<String> files) throws TopcatException, UnsupportedEncodingException {
+		DatafilesResponse response = new DatafilesResponse();
 		if (files.size() == 0) {
 			// Ensure that we don't error when calling .next() below by returning early
-			return datafileIds;
+			return response;
 		}
 
 		// Total limit - "entityManager?sessionId=" - `sessionId` - "?query=" - `queryPrefix` - `querySuffix
-		// Limit is 1024 - 24 - 36 - 7 - 51 - 17
+		// Limit is 1024 - 24 - 36 - 7 - 48 - 17
 		int getUrlLimit = Integer.parseInt(Properties.getInstance().getProperty("getUrlLimit", "1024"));
-		int chunkLimit = getUrlLimit - 135;
-		String queryPrefix = "SELECT d.id from Datafile d WHERE d.location in (";
+		int chunkLimit = getUrlLimit - 132;
+		String queryPrefix = "SELECT d from Datafile d WHERE d.location in (";
 		String querySuffix = ") ORDER BY d.id";
 		ListIterator<String> iterator = files.listIterator();
 
-		String chunkedFiles = "'" + iterator.next() + "'";
+		String file = iterator.next();
+		String chunkedFiles = "'" + file + "'";
+		response.missing.add(file);
 		int chunkSize = URLEncoder.encode(chunkedFiles, "UTF8").length();
 		while (iterator.hasNext()) {
-			String file = "'" + iterator.next() + "'";
-			int encodedFileLength = URLEncoder.encode(file, "UTF8").length();
+			file = iterator.next();
+			String quotedFile = "'" + file + "'";
+			int encodedFileLength = URLEncoder.encode(quotedFile, "UTF8").length();
 			if (chunkSize + 3 + encodedFileLength > chunkLimit) {
 				JsonArray jsonArray = submitQuery(queryPrefix + chunkedFiles + querySuffix);
-				for (JsonNumber datafileIdJsonNumber : jsonArray.getValuesAs(JsonNumber.class)) {
-					datafileIds.add(datafileIdJsonNumber.longValueExact());
+				for (JsonObject jsonObject : jsonArray.getValuesAs(JsonObject.class)) {
+					JsonObject datafile = jsonObject.getJsonObject("Datafile");
+					response.ids.add(datafile.getJsonNumber("id").longValueExact());
+					response.missing.remove(datafile.getString("location"));
+					response.totalSize += datafile.getJsonNumber("fileSize").longValueExact();
 				}
 
-				chunkedFiles = file;
+				chunkedFiles = quotedFile;
 				chunkSize = encodedFileLength;
+				response.missing.add(file);
 			} else {
-				chunkedFiles += "," + file;
+				chunkedFiles += "," + quotedFile;
 				chunkSize += 3 + encodedFileLength;  // 3 is size of , when encoded as %2C
+				response.missing.add(file);
 			}
 		}
 		JsonArray jsonArray = submitQuery(queryPrefix + chunkedFiles + querySuffix);
-		for (JsonNumber datafileIdJsonNumber : jsonArray.getValuesAs(JsonNumber.class)) {
-			datafileIds.add(datafileIdJsonNumber.longValueExact());
+		for (JsonObject jsonObject : jsonArray.getValuesAs(JsonObject.class)) {
+			JsonObject datafile = jsonObject.getJsonObject("Datafile");
+			response.ids.add(datafile.getJsonNumber("id").longValueExact());
+			response.missing.remove(datafile.getString("location"));
+			response.totalSize += datafile.getJsonNumber("fileSize").longValueExact();
 		}
 	
-		return datafileIds;
+		return response;
 	}
 
 	/**
@@ -207,6 +226,25 @@ public class IcatClient {
 			String query = "SELECT COUNT(datafile) FROM Datafile datafile WHERE datafile.dataset.id = " + datasetId;
 		JsonArray jsonArray = submitQuery(query);
 		return jsonArray.getJsonNumber(0).longValueExact();
+	}
+
+	/**
+	 * Utility method to get the fileSize (not size) of a Dataset by SELECTing its
+	 * child Datafiles. Ideally the fileSize field should be used, this is a
+	 * fallback option if that field is not set.
+	 * 
+	 * @param datasetId ICAT Dataset.id
+	 * @return The total size of Datafiles in the specified Dataset
+	 * @throws TopcatException
+	 */
+	public long getDatasetFileSize(long datasetId) throws TopcatException {
+			String query = "SELECT datafile.fileSize FROM Datafile datafile WHERE datafile.dataset.id = " + datasetId;
+		JsonArray jsonArray = submitQuery(query);
+		long size = 0L;
+		for (JsonNumber number : jsonArray.getValuesAs(JsonNumber.class)) {
+			size += number.longValueExact();
+		}
+		return size;
 	}
 
 	/**

--- a/src/main/java/org/icatproject/topcat/PriorityMap.java
+++ b/src/main/java/org/icatproject/topcat/PriorityMap.java
@@ -35,6 +35,10 @@ public class PriorityMap {
         Properties properties = Properties.getInstance();
 
         anonUserName = properties.getProperty("anonUserName", "");
+        if (anonUserName.equals("")) {
+            logger.warn("anonUserName not defined, cannot distinguish anonymous and authenticated users so "
+                    + "authenticated priority will be used as default level");
+        }
         anonDownloadEnabled = Boolean.parseBoolean(properties.getProperty("anonDownloadEnabled", "true"));
         String defaultString;
         if (anonDownloadEnabled) {

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -983,7 +983,8 @@ public class UserResource {
 	 *                     Download. Defaults to facilityName_visitId.
 	 * @param email        Optional email to notify upon completion
 	 * @param files        ICAT Datafile.locations to download
-	 * @return Array of Download ids
+	 * @return The resultant downloadId and an array of any locations which could not
+	 * 		   be found
 	 * @throws TopcatException
 	 * @throws UnsupportedEncodingException 
 	 */

--- a/src/test/java/org/icatproject/topcat/IcatClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IcatClientTest.java
@@ -12,6 +12,8 @@ import jakarta.ejb.EJB;
 import org.icatproject.topcat.httpclient.HttpClient;
 import org.icatproject.topcat.httpclient.Response;
 import org.icatproject.topcat.domain.*;
+import org.icatproject.topcat.exceptions.TopcatException;
+
 import java.net.URLEncoder;
 
 import org.icatproject.topcat.repository.CacheRepository;
@@ -236,6 +238,20 @@ public class IcatClientTest {
 
 			httpClient.delete("entityManager?sessionId=" + sessionId + "&entities=" + arrayBuilder.build(), new HashMap<>());
 		}
+	}
+
+	@Test
+	public void testGetDatasetFileCount() throws TopcatException {
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		long datasetId = icatClient.getEntity("Dataset").getJsonNumber("id").longValueExact();
+		assertNotEquals(0, icatClient.getDatasetFileCount(datasetId));
+	}
+
+	@Test
+	public void testGetDatasetFileSize() throws TopcatException {
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		long datasetId = icatClient.getEntity("Dataset").getJsonNumber("id").longValueExact();
+		assertNotEquals(0, icatClient.getDatasetFileSize(datasetId));
 	}
 
 	/*

--- a/src/test/java/org/icatproject/topcat/StatusCheckTest.java
+++ b/src/test/java/org/icatproject/topcat/StatusCheckTest.java
@@ -762,17 +762,12 @@ public class StatusCheckTest {
 
 			statusCheck.startQueuedDownloads(-1);
 
-			// All Downloads should have been prepared, but because they have dummy
-			// (non-UUID) sessionId when prepareData is called it will throw and then mark
-			// the Downloads as EXPIRED as part of the error handling. This is OK, as it
-			// still indicates startQueuedDownloads called prepareData
-
 			Download postDownload1 = TestHelpers.getDummyDownload(downloadId1, downloadRepository);
 			Download postDownload2 = TestHelpers.getDummyDownload(downloadId2, downloadRepository);
 
-			assertEquals(DownloadStatus.EXPIRED, postDownload1.getStatus());
+			assertEquals(DownloadStatus.PREPARING, postDownload1.getStatus());
 			assertNull(postDownload1.getPreparedId());
-			assertEquals(DownloadStatus.EXPIRED, postDownload2.getStatus());
+			assertEquals(DownloadStatus.PREPARING, postDownload2.getStatus());
 			assertNull(postDownload2.getPreparedId());
 		} finally {
 			// clean up
@@ -821,15 +816,10 @@ public class StatusCheckTest {
 
 			statusCheck.startQueuedDownloads(1);
 
-			// Should schedule only the first download, but because it has a dummy
-			// (non-UUID) sessionId when prepareData is called it will throw and then mark
-			// the Download as EXPIRED as part of the error handling. This is OK, as it
-			// still indicates startQueuedDownloads called prepareData
-
 			Download postDownload1 = TestHelpers.getDummyDownload(downloadId1, downloadRepository);
 			Download postDownload2 = TestHelpers.getDummyDownload(downloadId2, downloadRepository);
 
-			assertEquals(DownloadStatus.EXPIRED, postDownload1.getStatus());
+			assertEquals(DownloadStatus.PREPARING, postDownload1.getStatus());
 			assertNull(postDownload1.getPreparedId());
 			assertEquals(DownloadStatus.PAUSED, postDownload2.getStatus());
 			assertNull(postDownload2.getPreparedId());

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -17,10 +17,11 @@ queue.account.LILS.username=root
 queue.account.LILS.password=pw
 
 # Test data has 100 files per Dataset, set this to a small number to ensure coverage of the batching logic
-queue.maxFileCount = 1
+queue.visit.maxPartFileCount = 1
+queue.files.maxFileCount = 3
 queue.priority.user = {"simple/test": 1}
 queue.priority.default = 2
 
-# Each get request for Datafiles has a minimum size of 135, each of 3 locations is ~25
+# Each get request for Datafiles has a minimum size of 132, each of 3 locations is ~25
 # A value of 200 allows us to chunk this into one chunk of 2, and a second chunk of 1, hitting both branches of the code
 getUrlLimit=200

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -288,6 +288,90 @@ def manage_download_types():
 			}, verify=verifySsl).text)
 		download_statuses[option_number] = download_status
 
+
+def queue_visit():
+	transport = input("Enter transport mechanism: ")
+	email = input("Enter email to notify upon completion: ")
+	visit_id = input("Enter visit id: ")
+	data = {
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"transport": transport,
+		"email": email,
+		"visitId": visit_id,
+	}
+	url = topcat_url + "/user/queue/visit"
+	print(requests.post(url=url, data=data, verify=verifySsl).text)
+
+
+def queue_files():
+	transport = input("Enter transport mechanism: ")
+	email = input("Enter email to notify upon completion: ")
+	local_file = input("Enter path to local file containing newline delimited file locations: ")
+	with open(local_file) as f:
+		files = [l.strip() for l in f.readlines()]
+
+	data = {
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"transport": transport,
+		"email": email,
+		"files": files,
+	}
+	url = topcat_url + "/user/queue/files"
+	print(requests.post(url=url, data=data, verify=verifySsl).text)
+
+
+
+def get_all_queued_downloads():
+	query_offset = "WHERE download.isDeleted != true"
+	query_offset += " AND download.status = org.icatproject.topcat.domain.DownloadStatus.PAUSED"
+	query_offset += " AND download.preparedId = null"
+	params = {
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"queryOffset": query_offset,
+	}
+	return requests.get(topcat_url + "/admin/downloads", params=params, verify=verifySsl).text
+
+
+def prepare_download(download_id):
+	data = {
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"value": "PREPARING"
+	}
+	url = topcat_url + "/admin/download/" + download_id +  "/status"
+	requests.put(url=url, data=data, verify=verifySsl)
+
+
+def show_all_queued_downloads():
+	print(get_all_queued_downloads())
+
+
+def start_queued_download():
+	download_id = input("Enter download id: ")
+	prepare_download(download_id=download_id)
+
+
+def start_queued_downloads():
+	text = get_all_queued_downloads()
+	downloads = json.loads(text)
+	for download in  downloads:
+		prepare_download(str(download["id"]))
+
+
+def requeue_download():
+	download_id = input("Enter download id: ")
+	data = {
+		"facilityName": facility_name,
+		"sessionId": session_id,
+		"value": "PAUSED"
+	}
+	url = topcat_url + "/admin/download/" + download_id +  "/status"
+	requests.put(url=url, data=data, verify=verifySsl)
+
+
 while True:
 	print("")
 	print("What do you want to do?")
@@ -297,7 +381,13 @@ while True:
 	print(" * 4: Set a download status to 'EXPIRED'.")
 	print(" * 5: Expire all pending downloads.")
 	print(" * 6: Enable or disable download types.")
-	print(" * 7: Exit")
+	print(" * 7: Queue visit.")
+	print(" * 8: Queue files.")
+	print(" * 9: Show all queued downloads.")
+	print(" * 10: Start a queued download.")
+	print(" * 11: Start all queued downloads.")
+	print(" * 12: Re-queue expired download.")
+	print(" * 13: Exit")
 
 	option_number = input("Enter option number: ");
 
@@ -315,6 +405,18 @@ while True:
 	elif option_number == "6":
 		manage_download_types()
 	elif option_number == "7":
+		queue_visit()
+	elif option_number == "8":
+		queue_files()
+	elif option_number == "9":
+		show_all_queued_downloads()
+	elif option_number == "10":
+		start_queued_download()
+	elif option_number == "11":
+		start_queued_downloads()
+	elif option_number == "12":
+		requeue_download()
+	elif option_number == "13":
 		break
 	else:
 		print("")


### PR DESCRIPTION
- Limit number of files that can be submitted and remove the chunking into parts for `/queue/files`
- Calculate a running total for the fileSize of queued Downloads and set this directly instead of using the IDS
- 400 and 404 errors for submitting bad visitIds/files or those that do not exist/do not pass authz
- Only call `performCheck` when there's a `prepardId` to use
- Properly extract the functional sessionId used to prepare queued Downloads
- Tests
- Add options to the admin script for queue related things