### PR TITLE
Handle null fileSize SUM, null facilityName, int download_id

### DIFF
--- a/src/main/java/org/icatproject/topcat/FacilityMap.java
+++ b/src/main/java/org/icatproject/topcat/FacilityMap.java
@@ -71,7 +71,7 @@ public class FacilityMap {
 		}
 	}
 
-	private String validateFacilityName(String facility) throws InternalException {
+	public String validateFacilityName(String facility) throws InternalException {
 		if (facility == null) {
 			String defaultFacilityName = properties.getProperty("defaultFacilityName");
 			if (defaultFacilityName == null) {

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.icatproject.topcat.domain.*;
 
 import jakarta.json.*;
+import jakarta.json.JsonValue.ValueType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,7 +247,12 @@ public class IcatClient {
 	public long getDatasetFileSize(long datasetId) throws TopcatException {
 			String query = "SELECT SUM(datafile.fileSize) FROM Datafile datafile WHERE datafile.dataset.id = " + datasetId;
 		JsonArray jsonArray = submitQuery(query);
-		return jsonArray.getJsonNumber(0).longValueExact();
+		if (jsonArray.get(0).getValueType().equals(ValueType.NUMBER)) {
+			return jsonArray.getJsonNumber(0).longValueExact();
+		} else {
+			// SUM will be null if there are no matching Datafiles, so return 0
+			return 0L;
+		}
 	}
 
 	/**

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -881,6 +881,7 @@ public class UserResource {
 		logger.info("queueVisitId called for {}", visitId);
 		validateTransport(transport);
 
+		facilityName = validateFacilityName(facilityName);
 		String icatUrl = getIcatUrl(facilityName);
 		IcatClient icatClient = new IcatClient(icatUrl, sessionId);
 		String transportUrl = getDownloadUrl(facilityName, transport);
@@ -1004,6 +1005,7 @@ public class UserResource {
 		}
 		logger.info("queueFiles called for {} files", files.size());
 		validateTransport(transport);
+		facilityName = validateFacilityName(facilityName);
 		if (fileName == null) {
 			fileName = facilityName + "_files";
 		}
@@ -1177,6 +1179,14 @@ public class UserResource {
 
 	private Response emptyCart(String facilityName, String userName) {
 		return emptyCart(facilityName, userName, null);
+	}
+
+	private String validateFacilityName(String facilityName) throws BadRequestException {
+		try {
+			return FacilityMap.getInstance().validateFacilityName(facilityName);
+		} catch (InternalException ie){
+			throw new BadRequestException( ie.getMessage() );
+		}
 	}
 	
 	private String getIcatUrl( String facilityName ) throws BadRequestException{

--- a/src/test/java/org/icatproject/topcat/IcatClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IcatClientTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.*;
 import org.junit.*;
 
 import jakarta.json.*;
+import jakarta.json.JsonValue.ValueType;
 import jakarta.ejb.EJB;
 
 import org.icatproject.topcat.httpclient.HttpClient;
@@ -241,10 +242,28 @@ public class IcatClientTest {
 	}
 
 	@Test
+	public void testGetDatasets() throws TopcatException {
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonArray datasets = icatClient.getDatasets("Proposal 0 - 0 0");
+		for (JsonValue dataset : datasets) {
+			JsonArray datasetArray = dataset.asJsonArray();
+			assertEquals(datasetArray.get(0).getValueType(), ValueType.NUMBER);
+			assertEquals(datasetArray.get(1).getValueType(), ValueType.NUMBER);
+			assertEquals(datasetArray.get(2).getValueType(), ValueType.NUMBER);
+		}
+	}
+
+	@Test
 	public void testGetDatasetFileCount() throws TopcatException {
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
 		long datasetId = icatClient.getEntity("Dataset").getJsonNumber("id").longValueExact();
-		assertNotEquals(0, icatClient.getDatasetFileCount(datasetId));
+		assertNotEquals(0L, icatClient.getDatasetFileCount(datasetId));
+	}
+
+	@Test
+	public void testGetDatasetFileCountNotFound() throws TopcatException {
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		assertEquals(0L, icatClient.getDatasetFileCount(-1L));
 	}
 
 	@Test
@@ -252,6 +271,12 @@ public class IcatClientTest {
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
 		long datasetId = icatClient.getEntity("Dataset").getJsonNumber("id").longValueExact();
 		assertNotEquals(0, icatClient.getDatasetFileSize(datasetId));
+	}
+
+	@Test
+	public void testGetDatasetFileSizeNotFound() throws TopcatException {
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		assertEquals(0, icatClient.getDatasetFileSize(-1L));
 	}
 
 	/*

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -283,11 +283,10 @@ public class UserResourceTest {
 		System.out.println("DEBUG testQueueVisitId");
 		List<Long> downloadIds = new ArrayList<>();
 		try {
-			String facilityName = "LILS";
 			String transport = "http";
 			String email = "";
 			String visitId = "Proposal 0 - 0 0";
-			Response response = userResource.queueVisitId(facilityName, sessionId, transport, null, email, visitId);
+			Response response = userResource.queueVisitId(null, sessionId, transport, null, email, visitId);
 			assertEquals(200, response.getStatus());
 	
 			JsonArray downloadIdsArray = Utils.parseJsonArray(response.getEntity().toString());
@@ -351,7 +350,6 @@ public class UserResourceTest {
 		System.out.println("DEBUG testQueueFiles");
 		Long downloadId = null;
 		try {
-			String facilityName = "LILS";
 			String transport = "http";
 			String email = "";
 			String file = "abcdefghijklmnopqrstuvwxyz";
@@ -362,7 +360,7 @@ public class UserResourceTest {
 			for (JsonObject datafile : datafiles) {
 				files.add(datafile.getString("location"));
 			}
-			Response response = userResource.queueFiles(facilityName, sessionId, transport, null, email, files);
+			Response response = userResource.queueFiles(null, sessionId, transport, null, email, files);
 			assertEquals(200, response.getStatus());
 			JsonObject responseObject = Utils.parseJsonObject(response.getEntity().toString());
 			downloadId = responseObject.getJsonNumber("downloadId").longValueExact();

--- a/tools/datagateway_admin
+++ b/tools/datagateway_admin
@@ -114,7 +114,7 @@ def show_download():
 		print(requests.get(topcat_url + "/admin/downloads", params={
 			"facilityName": facility_name,
 			"sessionId": session_id,
-			"queryOffset": "where download.id = " + download_id
+			"queryOffset": f"where download.id = {download_id}"
 		}, verify=verifySsl).text)
 
 
@@ -124,7 +124,7 @@ def list_file_locations():
 		download = json.loads(requests.get(topcat_url + "/admin/downloads", params={
 			"facilityName": facility_name,
 			"sessionId": session_id,
-			"queryOffset": "where download.id = " + download_id
+			"queryOffset": f"where download.id = {download_id}"
 		}, verify=verifySsl).text)[0]
 		download_items = download["downloadItems"]
 		datafile_locations = []
@@ -175,7 +175,7 @@ def expire_download():
 
 def _expire_download(download_id):
 	response = requests.put(
-		topcat_url + "/admin/download/" + download_id +  "/status",
+		f"{topcat_url}/admin/download/{download_id}/status",
 		data={
 			"facilityName": facility_name,
 			"sessionId": session_id,
@@ -341,7 +341,7 @@ def start_download(download_id):
 		"sessionId": session_id,
 		"value": "PREPARING"
 	}
-	url = topcat_url + "/admin/download/" + download_id +  "/status"
+	url = f"{topcat_url}/admin/download/{download_id}/status"
 	response = requests.put(url=url, data=data, verify=verifySsl)
 	print(response.status_code, response.text)
 
@@ -369,7 +369,7 @@ def requeue_download():
 			"sessionId": session_id,
 			"value": "QUEUED"
 		}
-		url = topcat_url + "/admin/download/" + download_id +  "/status"
+		url = f"{topcat_url}/admin/download/{download_id}/status"
 		response = requests.put(url=url, data=data, verify=verifySsl)
 		print(response.status_code, response.text)
 


### PR DESCRIPTION
SUM of an empty list returns null, which was causing JSON casting exception. Now check the type, and return `0L` for the `null` case (an empty dataset should be treated as 0).

The default facilityName behaviour only worked for login. For the queue endpoints, it got the default urls OK but then facilityName was still null when it tried to persist the Download, which is not a nullable field. Now, get the default name for that as well as the urls.

The refactored `_expire_download` formatted the url such that `download_id` needed to be a string. This was the case for the direct call, but not option 5 which loads integers from the JSON response. Changed this and other locations to use f-strings, which will handle string or integer arguments gracefully.