### PR TITLE
Add download IDs to log messages

### DIFF
--- a/src/main/java/org/icatproject/topcat/StatusCheck.java
+++ b/src/main/java/org/icatproject/topcat/StatusCheck.java
@@ -173,14 +173,14 @@ public class StatusCheck {
     	  idsClient = new IdsClient(getDownloadUrl(download.getFacilityName(),download.getTransport()));
       }
       if(!download.getIsEmailSent() && download.getStatus() == DownloadStatus.COMPLETE){
-    	  logger.info("Download COMPLETE for " + download.getFileName() + "; checking whether to send email...");
+    	  logger.info("Download COMPLETE for " + download.getFileName() + " " + download.getId() + "; checking whether to send email...");
         download.setIsEmailSent(true);
         em.persist(download);
         em.flush();
         lastChecks.remove(download.getId());
         sendDownloadReadyEmail(download);
       } else if(download.getTransport().matches("https|http") && idsClient.isPrepared(download.getPreparedId())){
-    	  logger.info("Download (http[s]) for " + download.getFileName() + " is Prepared, so setting COMPLETE and checking email...");
+    	  logger.info("Download (http[s]) for " + download.getFileName() + " " + download.getId() + " is Prepared, so setting COMPLETE and checking email...");
         download.setStatus(DownloadStatus.COMPLETE);
         download.setCompletedAt(new Date());
         download.setIsEmailSent(true);
@@ -290,10 +290,10 @@ public class StatusCheck {
     }
 
     if (download.getIsTwoLevel() || !download.getTransport().matches("https|http")) {
-      logger.info("Setting Download status RESTORING for " + download.getFileName());
+      logger.info("Setting Download status RESTORING for " + download.getFileName() + " " + download.getId());
       download.setStatus(DownloadStatus.RESTORING);
     } else {
-      logger.info("Setting Download status COMPLETE for " + download.getFileName());
+      logger.info("Setting Download status COMPLETE for " + download.getFileName() + " " + download.getId());
       download.setStatus(DownloadStatus.COMPLETE);
       download.setCompletedAt(new Date());
     }


### PR DESCRIPTION
Whilst testing I noticed some log messages don't have download IDs in them. Reporting the filenames is not much help because they don't appear in the admin downloads table, so I've added the IDs as well.