### PR TITLE
Support transport mechanisms requiring email to be set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.icatproject</groupId>
 	<artifactId>datagateway-download-api</artifactId>
 	<packaging>war</packaging>
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<name>DataGateway Download API</name>
 	<description>Download backend for DataGateway</description>
 

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -50,6 +50,10 @@ mail.body.smartclient=Hi ${userName}, \n\nYour ${size} SmartClient download ${fi
 # The email body message for SCARF downloads. All subject tokens as above are available.
 mail.body.scarf=Hi ${userName}, \n\nYour ${size} SCARF download ${fileName} is ready. Please see https:/example.com/#/scarf-faq for more information on how to download using SCARF.\n\nThank you for using TopCAT
 
+# The email body message for Ada downloads. All subject tokens as above are available.
+mail.body.ada = Hi ${userName}, \n\nYour ${size} recall ${fileName} is ready as an Ada data share. Please visit https:/example.com to redeem access using the following token.\n\n${downloadUrl}\n\nThank you for using DataGateway
+mail.required.ada = true
+
 # The maximum number of datafiles for a getStatus call to the IDS for two level storage
 ids.getStatus.max=100
 

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -36,6 +36,7 @@ mail.enable=true
 # ${fileName} - the download name
 # ${size} - the download size
 # ${downloadUrl} - the download url
+# ${customValue} - optionally set by calls to setDownloadStatus where the status is complete
 mail.subject=TopCAT Download ${fileName} Ready
 
 # The email body message for https downloads. All subject tokens as above are available.
@@ -51,7 +52,7 @@ mail.body.smartclient=Hi ${userName}, \n\nYour ${size} SmartClient download ${fi
 mail.body.scarf=Hi ${userName}, \n\nYour ${size} SCARF download ${fileName} is ready. Please see https:/example.com/#/scarf-faq for more information on how to download using SCARF.\n\nThank you for using TopCAT
 
 # The email body message for Ada downloads. All subject tokens as above are available.
-mail.body.ada = Hi ${userName}, \n\nYour ${size} recall ${fileName} is ready as an Ada data share. Please visit https:/example.com to redeem access using the following token.\n\n${downloadUrl}\n\nThank you for using DataGateway
+mail.body.ada = Hi ${userName}, \n\nYour ${size} recall ${fileName} is ready as an Ada data share. Please visit https:/example.com to redeem access using the following token.\n\n${customValue}\n\nThank you for using DataGateway
 mail.required.ada = true
 
 # The maximum number of datafiles for a getStatus call to the IDS for two level storage

--- a/src/main/java/org/icatproject/topcat/web/rest/AdminResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/AdminResource.java
@@ -154,7 +154,7 @@ public class AdminResource {
      *
      * @param value the status value i.e. 'ONLINE', 'ARCHIVE' or 'RESTORING'.
      *
-     * @param customDownloadUrl Optional value to use in the email response body
+     * @param customValue Optional value to use in the email response body
      * 
      * @return an empty Response
      *
@@ -172,7 +172,7 @@ public class AdminResource {
         @FormParam("facilityName") String facilityName,
         @FormParam("sessionId") String sessionId,
         @FormParam("value") String value,
-        @FormParam("customDownloadUrl") String customDownloadUrl)
+        @FormParam("customValue") String customValue)
         throws TopcatException, MalformedURLException, ParseException {
 
         String icatUrl = getIcatUrl( facilityName );
@@ -192,9 +192,9 @@ public class AdminResource {
         }
         if(value.equals("COMPLETE")){
             download.setCompletedAt(new Date());
-            if (customDownloadUrl != null && !customDownloadUrl.equals("")) {
+            if (customValue != null && !customValue.equals("")) {
+                StatusCheck.sendDownloadReadyEmail(mailSession, download, null, customValue);
                 download.setIsEmailSent(true);
-                StatusCheck.sendDownloadReadyEmail(mailSession, download, customDownloadUrl);
             }
         }
 

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -1082,10 +1082,12 @@ public class UserResource {
 	}
 
 	/**
-	 * Validate that the submitted transport mechanism is not null or empty.
+	 * Validate that the submitted email is not null or empty if mail.required is true.
 	 * 
-	 * @param transport Transport mechanism to use
-	 * @throws BadRequestException if null or empty
+	 * @param transport Transport mechanism to use (which may require email)
+	 * @param email Users email address, which may be null or empty
+	 * @return The original email, or null if it was an empty string
+	 * @throws BadRequestException if email null or empty and mail.required is true
 	 */
 	private static String validateEmail(String transport, String email) throws BadRequestException {
 		if(email != null && email.equals("")){

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -730,6 +730,7 @@ public class UserResource {
 		}
 
 		validateTransport(transport);
+		email = validateEmail(transport, email);
 
 		String icatUrl = getIcatUrl( facilityName );
 		IcatClient icatClient = new IcatClient(icatUrl, sessionId);
@@ -745,11 +746,6 @@ public class UserResource {
 		Long downloadId = null;
 		String transportUrl = getDownloadUrl(facilityName, transport);
 		IdsClient idsClient = new IdsClient(transportUrl);
-
-		if(email != null && email.equals("")){
-			email = null;
-		}
-
 
 		if (cart != null) {
 			em.refresh(cart);
@@ -880,6 +876,7 @@ public class UserResource {
 		}
 		logger.info("queueVisitId called for {}", visitId);
 		validateTransport(transport);
+		email = validateEmail(transport, email);
 
 		facilityName = validateFacilityName(facilityName);
 		String icatUrl = getIcatUrl(facilityName);
@@ -1005,6 +1002,7 @@ public class UserResource {
 		}
 		logger.info("queueFiles called for {} files", files.size());
 		validateTransport(transport);
+		email = validateEmail(transport, email);
 		facilityName = validateFacilityName(facilityName);
 		if (fileName == null) {
 			fileName = facilityName + "_files";
@@ -1081,6 +1079,25 @@ public class UserResource {
 		if (transport == null || transport.trim().isEmpty()) {
 			throw new BadRequestException("transport is required");
 		}
+	}
+
+	/**
+	 * Validate that the submitted transport mechanism is not null or empty.
+	 * 
+	 * @param transport Transport mechanism to use
+	 * @throws BadRequestException if null or empty
+	 */
+	private static String validateEmail(String transport, String email) throws BadRequestException {
+		if(email != null && email.equals("")){
+			email = null;
+		}
+
+		String emailRequired = Properties.getInstance().getProperty("mail.required." + transport, "false");
+		if (Boolean.parseBoolean(emailRequired) && email == null) {
+			throw new BadRequestException("email is required for " + transport);
+		}
+
+		return email;
 	}
 
 	/**

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -165,7 +165,7 @@ public class AdminResourceTest {
 				downloadStatus = "PAUSED";
 			}
 	
-			response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, adminSessionId, downloadStatus);
+			response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, adminSessionId, downloadStatus, null);
 			assertEquals(200, response.getStatus());
 	
 			// and test that the new status has been set
@@ -211,7 +211,7 @@ public class AdminResourceTest {
 	
 			try {
 				response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, nonAdminSessionId,
-						downloadStatus);
+						downloadStatus, null);
 				// We should not see the following
 				System.out.println("DEBUG: AdminRT.setDownloadStatus response: " + response.getStatus() + ", "
 						+ (String) response.getEntity());
@@ -252,7 +252,7 @@ public class AdminResourceTest {
 			downloadRepository.save(testDownload);
 			downloadId = testDownload.getId();
 
-			Response response = adminResource.setDownloadStatus(downloadId, facilityName, adminSessionId, DownloadStatus.RESTORING.toString());
+			Response response = adminResource.setDownloadStatus(downloadId, facilityName, adminSessionId, DownloadStatus.RESTORING.toString(), null);
 			assertEquals(200, response.getStatus());
 
 			response = adminResource.getDownloads(facilityName, adminSessionId, null);
@@ -261,6 +261,74 @@ public class AdminResourceTest {
 
 			testDownload = findDownload(downloads, downloadId);
 			assertEquals(DownloadStatus.PREPARING, testDownload.getStatus());
+		} finally {
+			if (downloadId != null) {
+				downloadRepository.removeDownload(downloadId);
+			}
+		}
+	}
+
+	@Test
+	public void testSetDownloadStatusNoCustomDownloadUrl() throws Exception {
+		Long downloadId = null;
+		try {
+			Download testDownload = new Download();
+			String facilityName = "LILS";
+			testDownload.setFacilityName(facilityName);
+			testDownload.setSessionId(adminSessionId);
+			testDownload.setStatus(DownloadStatus.QUEUED);
+			testDownload.setIsDeleted(false);
+			testDownload.setUserName("simple/root");
+			testDownload.setFileName("testFile.txt");
+			testDownload.setTransport("http");
+			downloadRepository.save(testDownload);
+			downloadId = testDownload.getId();
+
+			Response response = adminResource.setDownloadStatus(downloadId, facilityName, adminSessionId,
+				DownloadStatus.COMPLETE.toString(), null);
+			assertEquals(200, response.getStatus());
+
+			response = adminResource.getDownloads(facilityName, adminSessionId, null);
+			assertEquals(200, response.getStatus());
+			List<Download> downloads = (List<Download>) response.getEntity();
+
+			testDownload = findDownload(downloads, downloadId);
+			assertEquals(DownloadStatus.COMPLETE, testDownload.getStatus());
+			assertFalse(testDownload.getIsEmailSent());
+		} finally {
+			if (downloadId != null) {
+				downloadRepository.removeDownload(downloadId);
+			}
+		}
+	}
+
+	@Test
+	public void testSetDownloadStatusCustomDownloadUrl() throws Exception {
+		Long downloadId = null;
+		try {
+			Download testDownload = new Download();
+			String facilityName = "LILS";
+			testDownload.setFacilityName(facilityName);
+			testDownload.setSessionId(adminSessionId);
+			testDownload.setStatus(DownloadStatus.QUEUED);
+			testDownload.setIsDeleted(false);
+			testDownload.setUserName("simple/root");
+			testDownload.setFileName("testFile.txt");
+			testDownload.setTransport("http");
+			downloadRepository.save(testDownload);
+			downloadId = testDownload.getId();
+
+			Response response = adminResource.setDownloadStatus(downloadId, facilityName, adminSessionId,
+				DownloadStatus.COMPLETE.toString(), "customDownloadUrl");
+			assertEquals(200, response.getStatus());
+
+			response = adminResource.getDownloads(facilityName, adminSessionId, null);
+			assertEquals(200, response.getStatus());
+			List<Download> downloads = (List<Download>) response.getEntity();
+
+			testDownload = findDownload(downloads, downloadId);
+			assertEquals(DownloadStatus.COMPLETE, testDownload.getStatus());
+			assertTrue(testDownload.getIsEmailSent());
 		} finally {
 			if (downloadId != null) {
 				downloadRepository.removeDownload(downloadId);

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -307,7 +307,7 @@ public class UserResourceTest {
 				assertEquals(transport, download.getTransport());
 				assertEquals("simple/root", download.getUserName());
 				assertEquals("simple/root", download.getFullName());
-				assertEquals("", download.getEmail());
+				assertEquals(null, download.getEmail());
 				assertNotEquals(0L, download.getSize());
 				part += 1;
 			}
@@ -377,7 +377,7 @@ public class UserResourceTest {
 			assertEquals(transport, download.getTransport());
 			assertEquals("simple/root", download.getUserName());
 			assertEquals("simple/root", download.getFullName());
-			assertEquals("", download.getEmail());
+			assertEquals(null, download.getEmail());
 			assertNotEquals(0L, download.getSize());
 		} finally {
 			if (downloadId != null) {
@@ -535,6 +535,38 @@ public class UserResourceTest {
 				TestHelpers.deleteDummyDownload(downloadId, downloadRepository);
 			});
 		}
+	}
+
+	@Test
+	public void testRequiredEmail() throws Exception {
+		String facilityName = "LILS";
+		Response response;
+		List<Download> downloads;
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		JsonObject dataset = icatClient.getEntity("dataset");
+		long entityId = dataset.getInt("id");
+
+		// Get the initial state of the downloads - may not be empty
+		response = userResource.getDownloads(facilityName, sessionId, null);
+		assertEquals(200, response.getStatus());
+
+		downloads = (List<Download>) response.getEntity();
+		int initialDownloadsSize = downloads.size();
+
+		// TEST logging
+		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize);
+
+		// Put something into the Cart, so we have something to submit
+		response = userResource.addCartItems(facilityName, sessionId, "dataset " + entityId, false);
+		assertEquals(200, response.getStatus());
+
+		// Now submit it
+		String transport = "ada";
+		String email = "";
+		String fileName = "dataset-1.zip";
+		String zipType = "ZIP";
+		assertThrows(BadRequestException.class,
+			() -> userResource.submitCart(facilityName, sessionId, transport, email, fileName, zipType));
 	}
 
 	private int getCartSize(Response response) throws Exception {

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -25,3 +25,5 @@ queue.priority.default = 2
 # Each get request for Datafiles has a minimum size of 132, each of 3 locations is ~25
 # A value of 200 allows us to chunk this into one chunk of 2, and a second chunk of 1, hitting both branches of the code
 getUrlLimit=200
+
+mail.required.ada = true


### PR DESCRIPTION
Impact:
- New mechanism for sending email with a custom value of `downloadUrl` when (pollcat) marks the Download as COMPLETE
  - In practice, for Ada restores this doesn't have to be a full url but can just be the share token
- Transport mechanisms can require an email to be provided
  - This would be necessary for Ada restores as we need to send the share token by email

Changes:
- Decouple marking Downloads as COMPLETE from sending the email in StatusCheck
- Refactor `sendDownloadReadyEmail` so that it can be re-used for custom values of `downloadUrl`
- `setDownloadStatus` now accepts a custom `downloadUrl` which if set, will trigger the email to be sent then (rather than later by the StatusCheck).
- Refactor email validation and implement check when the transport mechanism requires it
- New test