### PR TITLE
Use admin's sessionId when setting DownloadStatus to PREPARING

### DIFF
--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -247,7 +247,7 @@ public class AdminResourceTest {
 			Download testDownload = new Download();
 			String facilityName = "LILS";
 			testDownload.setFacilityName(facilityName);
-			testDownload.setSessionId(adminSessionId);
+			testDownload.setSessionId("sessionId");
 			testDownload.setStatus(DownloadStatus.QUEUED);
 			testDownload.setIsDeleted(false);
 			testDownload.setUserName("simple/root");
@@ -265,6 +265,7 @@ public class AdminResourceTest {
 
 			testDownload = findDownload(downloads, downloadId);
 			assertEquals(DownloadStatus.PREPARING, testDownload.getStatus());
+			assertEquals(adminSessionId, testDownload.getSessionId());
 		} finally {
 			if (downloadId != null) {
 				downloadRepository.removeDownload(downloadId);


### PR DESCRIPTION
Similarly to how calls to `PUT /download/{id}/prepare` use the admin's sessionId for the call to the IDS, now calls to `PUT /download/{id}/status` with a status of `PREPARING` will also overwrite the (old) sessionId with the new one in the request. We are already doing this in the former location, and the contents of the cart should already be authorized (by adding the individual items to a cart or when queuing for the first time).

Closes #95 