### PR TITLE
Add /search/files endpoint using icat.lucene

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -156,6 +156,11 @@ queue.priority.investigationUser.default = 4
 queue.priority.authenticated = {"orcid": 6, "anon": 0}
 queue.priority.default = 5
 
+# Whether the API endpoint perform Lucene searches is enabled
+search.enabled = false
+# The maximum number of results to return in a single request to the Lucene component
+search.maxResults = 10000
+
 # Configurable limit for the length of the GET URL for requesting Datafiles by a list of file locations
 # The exact limit may depend on the server
 getUrlLimit=1024

--- a/src/main/java/org/icatproject/topcat/httpclient/HttpClient.java
+++ b/src/main/java/org/icatproject/topcat/httpclient/HttpClient.java
@@ -34,23 +34,32 @@ public class HttpClient {
 	}
 
 	public Response get(String offset, Map<String, String> headers, int readTimeout) throws Exception {
-		return send("GET", offset, headers, null, readTimeout);
+		return send("GET", offset, headers, null, readTimeout, null);
 	}
 
 	public Response get(String offset, Map<String, String> headers) throws Exception {
 		return get(offset, headers, -1);
 	}
 
+	public Response post(String offset, Map<String, String> headers, String data, int readTimeout, String contentType)
+			throws Exception {
+		return send("POST", offset, headers, data, readTimeout, contentType);
+	}
+
 	public Response post(String offset, Map<String, String> headers, String data, int readTimeout) throws Exception {
-		return send("POST", offset, headers, data, readTimeout);
+		return send("POST", offset, headers, data, readTimeout, null);
+	}
+
+	public Response post(String offset, Map<String, String> headers, String data, String contentType) throws Exception {
+		return post(offset, headers, data, -1, contentType);
 	}
 
 	public Response post(String offset, Map<String, String> headers, String data) throws Exception {
-		return post(offset, headers, data, -1);
+		return post(offset, headers, data, -1, null);
 	}
 
 	public Response delete(String offset, Map<String, String> headers, int readTimeout) throws Exception {
-		return send("DELETE", offset, headers, null, readTimeout);
+		return send("DELETE", offset, headers, null, readTimeout, null);
 	}
 
 	public Response delete(String offset, Map<String, String> headers) throws Exception {
@@ -58,7 +67,7 @@ public class HttpClient {
 	}
 
 	public Response put(String offset, Map<String, String> headers, String data, int readTimeout) throws Exception {
-		return send("PUT", offset, headers, data, readTimeout);
+		return send("PUT", offset, headers, data, readTimeout, null);
 	}
 
 	public Response put(String offset, Map<String, String> headers, String data) throws Exception {
@@ -66,14 +75,15 @@ public class HttpClient {
 	}
 
 	public Response head(String offset, Map<String, String> headers, int readTimeout) throws Exception {
-		return send("HEAD", offset, headers, null, readTimeout);
+		return send("HEAD", offset, headers, null, readTimeout, null);
 	}
 
 	public Response head(String offset, Map<String, String> headers) throws Exception {
 		return head(offset, headers, -1);
 	}
 
-	private Response send(String method, String offset, Map<String, String> headers, String body, int readTimeout) throws Exception {
+	private Response send(String method, String offset, Map<String, String> headers, String body, int readTimeout,
+			String contentType) throws Exception {
 		StringBuilder url = new StringBuilder(this.url + "/" + offset);
 
 		HttpURLConnection connection = null;
@@ -95,12 +105,14 @@ public class HttpClient {
     		if(body != null && (method.equals("POST") || method.equals("PUT"))){
     			connection.setDoOutput(true);
     			connection.setRequestProperty("Content-Length", Integer.toString(body.toString().getBytes().length));
+				if (contentType != null) {
+					connection.setRequestProperty("Content-Type", contentType);
+				}
 
 	    		DataOutputStream request = new DataOutputStream(connection.getOutputStream());
 	    		request.writeBytes(body.toString());
 	    		request.close();
 	    	}
-
 	    	Integer responseCode = connection.getResponseCode();
 
 	    	Map<String, String> responseHeaders = new HashMap();

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -497,7 +497,6 @@ public class UserResourceTest {
 	@Test
 	public void testSearchFiles() throws Exception {
 		System.out.println("DEBUG testSearchFiles");
-		double expectedScore = 1.9460127353668213;
 		Response response = userResource.searchFiles(null, sessionId, 100, "visitId:\"Proposal 0 - 0 0\"", null);
 		assertEquals(200, response.getStatus());
 		JsonObject responseObject = Utils.parseJsonObject(response.getEntity().toString());
@@ -507,10 +506,10 @@ public class UserResourceTest {
 		JsonObject firstSearchAfterObject = Utils.parseJsonObject(firstSearchAfter);
 		JsonArray firstFields = firstSearchAfterObject.getJsonArray("fields");
 		int firstDoc = firstSearchAfterObject.getJsonNumber("doc").intValueExact();
+		double firstScore = firstFields.getJsonNumber(0).doubleValue();
 		long firstIcatId = firstFields.getJsonNumber(1).longValueExact();
 		assertEquals(0, firstSearchAfterObject.getJsonNumber("shardIndex").intValueExact());
-		assertEquals(expectedScore, firstSearchAfterObject.getJsonNumber("score").doubleValue());
-		assertEquals(expectedScore, firstFields.getJsonNumber(0).doubleValue());
+		assertEquals(firstScore, firstSearchAfterObject.getJsonNumber("score").doubleValue());
 
 		// If maxResults is not provided, it will default to 0 and then should use the queue.maxFileCount value of 3
 		response = userResource.searchFiles(null, sessionId, 0, "+visitId:\"Proposal 0 - 0 0\"", firstSearchAfter);
@@ -522,9 +521,9 @@ public class UserResourceTest {
 		JsonObject secondSearchAfterObject = Utils.parseJsonObject(secondSearchAfter);
 		JsonArray secondFields = secondSearchAfterObject.getJsonArray("fields");
 		assertEquals(0, secondSearchAfterObject.getJsonNumber("shardIndex").intValueExact());
-		assertEquals(expectedScore, secondSearchAfterObject.getJsonNumber("score").doubleValue());
-		assertEquals(expectedScore, secondFields.getJsonNumber(0).doubleValue());
 		assertEquals(firstDoc + 3, secondSearchAfterObject.getJsonNumber("doc").intValueExact());
+		assertEquals(firstScore, secondSearchAfterObject.getJsonNumber("score").doubleValue());
+		assertEquals(firstScore, secondFields.getJsonNumber(0).doubleValue());
 		assertEquals(firstIcatId + 3, secondFields.getJsonNumber(1).longValueExact());
 	}
 

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -521,7 +521,7 @@ public class UserResourceTest {
 		JsonObject secondSearchAfterObject = Utils.parseJsonObject(secondSearchAfter);
 		JsonArray secondFields = secondSearchAfterObject.getJsonArray("fields");
 		assertEquals(0, secondSearchAfterObject.getJsonNumber("shardIndex").intValueExact());
-		assertEquals(firstDoc + 3, secondSearchAfterObject.getJsonNumber("doc").intValueExact());
+		assertTrue(secondSearchAfterObject.getJsonNumber("doc").intValueExact() >= firstDoc + 3);
 		assertEquals(firstScore, secondSearchAfterObject.getJsonNumber("score").doubleValue());
 		assertEquals(firstScore, secondFields.getJsonNumber(0).doubleValue());
 		assertEquals(firstIcatId + 3, secondFields.getJsonNumber(1).longValueExact());

--- a/src/test/resources/run.properties
+++ b/src/test/resources/run.properties
@@ -42,6 +42,8 @@ queue.priority.user = {"simple/test": 1}
 queue.priority.authenticated = {"anon": 0}
 queue.priority.default = 2
 
+search.enabled = true
+
 # Each get request for Datafiles has a minimum size of 132, each of 3 locations is ~25
 # A value of 200 allows us to chunk this into one chunk of 2, and a second chunk of 1, hitting both branches of the code
 getUrlLimit=200


### PR DESCRIPTION
Add an optional endpoint which accepts and sends Lucene formatted queries to the icat.lucene component.

If the user `isAdmin`, then this will not perform any authz. Otherwise, the ICAT username is included with the search which will limit results to those where the user is InstrumentScientist/InvestigationUser. This logic is pre-existing and used in icat.server to do post search authz. That process is limited by the maxIdsInQuery value (500 in production). Querying icat.lucene directly lets us bypass this and so return ~10,000 results in ~second rather than 500. It does however make assumptions about the state of the Rules, which is why it's optional.

Closes #98 