### PR TITLE
Add endpoints for visit, files size. Include size in search.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.venv
 /bin
 /target
 /plugins/*/

--- a/src/main/java/org/icatproject/topcat/DownloadBuilder.java
+++ b/src/main/java/org/icatproject/topcat/DownloadBuilder.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
 
 public class DownloadBuilder {
@@ -39,14 +41,21 @@ public class DownloadBuilder {
     public String fileName;
 	public final List<Download> downloads = new ArrayList<Download>();
 
-    public DownloadBuilder(String sessionId, String email, String fileName, String transport, String facilityName) throws TopcatException {
+	/**
+	 * Initialise with minimal settings to performing querying for a potential
+	 * queued Download, but not actually submitting it.
+	 * 
+	 * @param sessionId    ICAT sessionId.
+	 * @param facilityName ICAT Facility.name.
+	 * @throws TopcatException if facilityName is invalid, or queueing not allowed
+	 *                         for this sessionId.
+	 */
+	public DownloadBuilder(String sessionId, String facilityName) throws TopcatException {
 		Properties properties = Properties.getInstance();
 		queueVisitMaxPartFileCount = Long.valueOf(properties.getProperty("queue.visit.maxPartFileCount", "10000"));
 		queueFilesMaxFileCount = Long.valueOf(properties.getProperty("queue.files.maxFileCount", "10000"));
 
-        this.sessionId = sessionId;
-        this.fileName = fileName;
-		this.transport = validateTransport(transport);
+		this.sessionId = sessionId;
 		this.facilityName = validateFacilityName(facilityName);
 		this.email = validateEmail(transport, email);
 		String icatUrl = getIcatUrl(this.facilityName);
@@ -57,7 +66,27 @@ public class DownloadBuilder {
 		fullName = icatClient.getFullName();
 		priority = icatClient.getQueuePriority(userName);
 		icatClient.checkQueueAllowed(userName);
-    }
+	}
+
+	/**
+	 * Initialise with all settings, suitable for submitting Downloads.
+	 * 
+	 * @param sessionId    ICAT sessionId.
+	 * @param email        Optional email to notify upon completion.
+	 * @param fileName     Optional name to use as the root for each individual part
+	 *                     Download. Defaults to facilityName_visitId.
+	 * @param transport    Transport mechanism to use.
+	 * @param facilityName ICAT Facility.name.
+	 * @throws TopcatException if facilityName is invalid, or queueing not allowed
+	 *                         for this sessionId.
+	 */
+	public DownloadBuilder(String sessionId, String email, String fileName, String transport, String facilityName)
+			throws TopcatException {
+		this(sessionId, facilityName);
+		this.fileName = fileName;
+		this.transport = validateTransport(transport);
+		this.email = validateEmail(transport, email);
+	}
 
 	/**
 	 * Validate that the submitted transport mechanism is not null or empty.
@@ -196,7 +225,44 @@ public class DownloadBuilder {
 		}
 
 		buildDownloads(datasets, datafiles);
-    }
+	}
+
+	/**
+	 * Get the fileCount and fileSize of the specified visit.
+	 * 
+	 * @param visitId ICAT Investigation.visitId.
+	 * @return JsonObject in the format {"totalCount": 0, "totalSize": 0}
+	 * @throws TopcatException if querying ICAT fails.
+	 */
+	public JsonObject getVisitSize(String visitId) throws TopcatException {
+		if (visitId == null || visitId.equals("")) {
+			throw new BadRequestException("visitId must be provided");
+		}
+		JsonArray investigations = icatClient.getInvestigation(visitId);
+		if (investigations.size() == 0) {
+			throw new NotFoundException("No Investigations found for " + visitId);
+		}
+		long totalCount = 0;
+		long totalSize = 0;
+		for (JsonArray investigation : investigations.getValuesAs(JsonArray.class)) {
+			long investigationId = investigation.getJsonNumber(0).longValueExact();
+			long investigationFileCount = investigation.getJsonNumber(1).longValueExact();
+			long investigationFileSize = investigation.getJsonNumber(2).longValueExact();
+			// Database triggers should set these, but check explicitly anyway
+			if (investigationFileCount < 1L) {
+				investigationFileCount = icatClient.getInvestigationFileCount(investigationId);
+			}
+			if (investigationFileSize < 1L) {
+				investigationFileSize = icatClient.getInvestigationFileSize(investigationId);
+			}
+			totalCount += investigationFileCount;
+			totalSize += investigationFileSize;
+		}
+		JsonObjectBuilder builder = Json.createObjectBuilder();
+		builder.add("totalCount", totalCount);
+		builder.add("totalSize", totalSize);
+		return builder.build();
+	}
 
 	/**
 	 * Adds Datasets from an Investigation as DownloadItems.

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -46,6 +46,18 @@ public class IcatClient {
 				totalSize += datafile.getJsonNumber("fileSize").longValueExact();
 			}
 		}
+
+		/**
+		 * @return JsonObject in the format
+		 *         {"totalCount": 0, "totalSize": 0, "notFound": []}.
+		 */
+		public JsonObject buildSizeResponseBody() {
+			JsonObjectBuilder builder = Json.createObjectBuilder();
+			builder.add("totalCount", ids.size());
+			builder.add("totalSize", totalSize);
+			builder.add("notFound", Json.createArrayBuilder(missing));
+			return builder.build();
+		}
 	}
 
 	/**
@@ -275,6 +287,19 @@ public class IcatClient {
 	}
 
 	/**
+	 * Get the Investigations with the specified visitId.
+	 * 
+	 * @param visitId ICAT Investigation.visitId
+	 * @return JsonArray of Investigation fields, where each entry is a JsonArray of
+	 *         [investigation.id, investigation.fileCount, investigation.fileSize].
+	 * @throws TopcatException
+	 */
+	public JsonArray getInvestigation(String visitId) throws TopcatException {
+		String query = "SELECT i.id, i.fileCount, i.fileSize from Investigation i WHERE i.visitId = '" + visitId + "'";
+		return submitQuery(query);
+	}
+
+	/**
 	 * Get all Datasets whose parent Investigation has the specified visitId.
 	 * 
 	 * @param visitId ICAT Investigation.visitId
@@ -367,6 +392,41 @@ public class IcatClient {
 		query += " WHERE dataCollectionDatafile.dataCollection.id = " + dataCollectionId;
 		query += " ORDER BY dataCollectionDatafile.datafile.id";
 		return submitQuery(query);
+	}
+
+	/**
+	 * Utility method to get the fileCount (not size) of an Investigation by COUNT
+	 * of its child Datafiles. Ideally the fileCount field should be used, this is
+	 * a fallback option if that field is not set.
+	 * 
+	 * @param investigationId ICAT Investigation.id
+	 * @return The number of Datafiles in the specified Investigation
+	 * @throws TopcatException
+	 */
+	public long getInvestigationFileCount(long investigationId) throws TopcatException {
+		String query = "SELECT COUNT(d) FROM Datafile d WHERE d.dataset.investigation.id = " + investigationId;
+		JsonArray jsonArray = submitQuery(query);
+		return jsonArray.getJsonNumber(0).longValueExact();
+	}
+
+	/**
+	 * Utility method to get the fileSize (not size) of an Investigation by
+	 * SELECTing its child Datafiles. Ideally the fileSize field should be used,
+	 * this is a fallback option if that field is not set.
+	 * 
+	 * @param investigationId ICAT Investigation.id
+	 * @return The total size of Datafiles in the specified Investigation
+	 * @throws TopcatException
+	 */
+	public long getInvestigationFileSize(long investigationId) throws TopcatException {
+		String query = "SELECT SUM(d.fileSize) FROM Datafile d WHERE d.dataset.investigation.id = " + investigationId;
+		JsonArray jsonArray = submitQuery(query);
+		if (jsonArray.get(0).getValueType().equals(ValueType.NUMBER)) {
+			return jsonArray.getJsonNumber(0).longValueExact();
+		} else {
+			// SUM will be null if there are no matching Datafiles, so return 0
+			return 0L;
+		}
 	}
 
 	/**
@@ -585,6 +645,7 @@ public class IcatClient {
 	 * @throws TopcatException
 	 */
 	public int getQueuePriority(String userName) throws TopcatException {
+		logger.debug("Get priority for {}", userName);
 		PriorityMap priorityMap = PriorityMap.getInstance();
 		Integer userPriority = priorityMap.getUserPriority(userName);
 		if (userPriority != null) {

--- a/src/main/java/org/icatproject/topcat/IcatClient.java
+++ b/src/main/java/org/icatproject/topcat/IcatClient.java
@@ -410,12 +410,12 @@ public class IcatClient {
 	}
 
 	/**
-	 * Utility method to get the fileSize (not size) of an Investigation by
+	 * Utility method to get the fileSize (not count) of an Investigation by
 	 * SELECTing its child Datafiles. Ideally the fileSize field should be used,
 	 * this is a fallback option if that field is not set.
 	 * 
 	 * @param investigationId ICAT Investigation.id
-	 * @return The total size of Datafiles in the specified Investigation
+	 * @return The total size (in bytes) of Datafiles in the specified Investigation
 	 * @throws TopcatException
 	 */
 	public long getInvestigationFileSize(long investigationId) throws TopcatException {
@@ -445,12 +445,12 @@ public class IcatClient {
 	}
 
 	/**
-	 * Utility method to get the fileSize (not size) of a Dataset by SELECTing its
+	 * Utility method to get the fileSize (not count) of a Dataset by SELECTing its
 	 * child Datafiles. Ideally the fileSize field should be used, this is a
 	 * fallback option if that field is not set.
 	 * 
 	 * @param datasetId ICAT Dataset.id
-	 * @return The total size of Datafiles in the specified Dataset
+	 * @return The total size (in bytes) of Datafiles in the specified Dataset
 	 * @throws TopcatException
 	 */
 	public long getDatasetFileSize(long datasetId) throws TopcatException {

--- a/src/main/java/org/icatproject/topcat/PriorityMap.java
+++ b/src/main/java/org/icatproject/topcat/PriorityMap.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.json.Json;
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 
@@ -90,11 +91,14 @@ public class PriorityMap {
      * @param mapping        HashMap from String key to numeric priority level
      */
     private void parseObject(String propertyString, HashMap<String, Integer> mapping) {
-        JsonReader reader = Json.createReader(new ByteArrayInputStream(propertyString.getBytes()));
-        JsonObject object = reader.readObject();
-        for (String key : object.keySet()) {
-            int priority = object.getInt(key);
-            mapping.put(key, priority);
+        try (JsonReader reader = Json.createReader(new ByteArrayInputStream(propertyString.getBytes()))) {
+            JsonObject object = reader.readObject();
+            for (String key : object.keySet()) {
+                int priority = object.getInt(key);
+                mapping.put(key, priority);
+            }
+        } catch (JsonException e) {
+            logger.error("Could not parse {} as JSON object, defaulting to empty object", propertyString);
         }
     }
 

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -1038,8 +1038,50 @@ public class UserResource {
 	}
 
 	/**
-	 * Perform a search using the icat.lucene component for Datafile.locations, so that
-	 * these can then be used with the /queue/files endpoint.
+	 * Get the total size of a visit.
+	 * 
+	 * @param facilityName ICAT Facility.name.
+	 * @param sessionId    ICAT sessionId.
+	 * @param visitId      ICAT Investigation.visitId.
+	 * @return The "totalCount" and "totalSize" of all Datafiles in this visit.
+	 * @throws TopcatException              if querying ICAT fails.
+	 * @throws UnsupportedEncodingException if query encoding fails.
+	 */
+	@POST
+	@Path("/getSize/visit")
+	public Response getSizeVisit(@FormParam("facilityName") String facilityName,
+			@FormParam("sessionId") String sessionId, @FormParam("visitId") String visitId)
+			throws TopcatException, UnsupportedEncodingException {
+		logger.info("Get size of {}", visitId);
+		DownloadBuilder downloadBuilder = new DownloadBuilder(sessionId, facilityName);
+		return Response.ok(downloadBuilder.getVisitSize(visitId)).build();
+	}
+
+	/**
+	 * Get the total size of a list of files.
+	 * 
+	 * @param facilityName ICAT Facility.name.
+	 * @param sessionId    ICAT sessionId.
+	 * @param files        ICAT Datafile.locations to download.
+	 * @return The "totalSize" and an array of any "notFound" locations which could
+	 *         not be found by the query.
+	 * @throws TopcatException              if querying ICAT fails.
+	 * @throws UnsupportedEncodingException if query encoding fails.
+	 */
+	@POST
+	@Path("/getSize/files")
+	public Response getSizeFiles(@FormParam("facilityName") String facilityName,
+			@FormParam("sessionId") String sessionId, @FormParam("files") List<String> files)
+			throws TopcatException, UnsupportedEncodingException {
+		DownloadBuilder downloadBuilder = new DownloadBuilder(sessionId, facilityName);
+		logger.info("Get size of {} files", files.size());
+		DatafilesResponse response = downloadBuilder.extractLocations(files);
+		return Response.ok(response.buildSizeResponseBody()).build();
+	}
+
+	/**
+	 * Perform a search using the icat.lucene component for Datafile.locations, so
+	 * that these can then be used with the /queue/files endpoint.
 	 * 
 	 * Must be explicitly enabled by the run.properties.
 	 * 
@@ -1084,6 +1126,7 @@ public class UserResource {
 
 		JsonArrayBuilder fieldsBuilder = Json.createArrayBuilder();
 		fieldsBuilder.add("location");
+		fieldsBuilder.add("fileSize");
 		JsonObjectBuilder queryBuilder = Json.createObjectBuilder();
 		queryBuilder.add("text", query);
 		if (!icatClient.isAdmin()) {

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -1043,7 +1043,8 @@ public class UserResource {
 	 * @param facilityName ICAT Facility.name.
 	 * @param sessionId    ICAT sessionId.
 	 * @param visitId      ICAT Investigation.visitId.
-	 * @return The "totalCount" and "totalSize" of all Datafiles in this visit.
+	 * @return The "totalCount" and "totalSize" (in bytes) of all Datafiles in this
+	 *         visit.
 	 * @throws TopcatException              if querying ICAT fails.
 	 * @throws UnsupportedEncodingException if query encoding fails.
 	 */
@@ -1063,8 +1064,8 @@ public class UserResource {
 	 * @param facilityName ICAT Facility.name.
 	 * @param sessionId    ICAT sessionId.
 	 * @param files        ICAT Datafile.locations to download.
-	 * @return The "totalSize" and an array of any "notFound" locations which could
-	 *         not be found by the query.
+	 * @return The "totalSize" (in bytes) and an array of any "notFound" locations which
+	 *         could not be found by the query.
 	 * @throws TopcatException              if querying ICAT fails.
 	 * @throws UnsupportedEncodingException if query encoding fails.
 	 */

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -429,6 +429,17 @@ public class UserResourceTest {
 	}
 
 	@Test
+	public void testGetSizeVisit() throws Exception {
+		System.out.println("DEBUG testGetSizeVisit");
+		String visitId = "Proposal 0 - 0 0";
+		Response response = userResource.getSizeVisit(null, sessionId, visitId);
+		assertEquals(200, response.getStatus());
+		JsonObject jsonObject = Utils.parseJsonObject(response.getEntity().toString());
+		assertEquals(300L, jsonObject.getJsonNumber("totalCount").longValueExact());
+		assertTrue(jsonObject.getJsonNumber("totalSize").longValueExact() > 0L); // Sizes are random
+	}
+
+	@Test
 	public void testQueueVisitIdBadRequest() throws Exception {
 		System.out.println("DEBUG testQueueVisitIdBadRequest");
 		String facilityName = "LILS";
@@ -498,14 +509,40 @@ public class UserResourceTest {
 	}
 
 	@Test
+	public void testGetSizeFiles() throws Exception {
+		System.out.println("DEBUG testGetSizeFiles");
+		String file = "abcdefghijklmnopqrstuvwxyz";
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		List<JsonObject> datafiles = icatClient.getEntities("datafile", 2L);
+		List<String> files = new ArrayList<>();
+		files.add(file);
+		for (JsonObject datafile : datafiles) {
+			files.add(datafile.getString("location"));
+		}
+		Response response = userResource.getSizeFiles(null, sessionId, files);
+		assertEquals(200, response.getStatus());
+		JsonObject jsonObject = Utils.parseJsonObject(response.getEntity().toString());
+		assertEquals(2L, jsonObject.getJsonNumber("totalCount").longValueExact());
+		assertTrue(jsonObject.getJsonNumber("totalSize").longValueExact() > 0L); // Sizes are random
+		JsonArray missing = jsonObject.getJsonArray("notFound");
+		assertEquals(1, missing.size());
+		assertEquals(file, missing.getString(0));
+	}
+
+	@Test
 	public void testSearchFiles() throws Exception {
 		System.out.println("DEBUG testSearchFiles");
 		Response response = userResource.searchFiles(null, sessionId, 100, "visitId:\"Proposal 0 - 0 0\"", null);
 		assertEquals(200, response.getStatus());
 		JsonObject responseObject = Utils.parseJsonObject(response.getEntity().toString());
 		JsonArray results = responseObject.getJsonArray("results");
-		String firstSearchAfter = responseObject.getJsonObject("search_after").toString();
 		assertEquals(100, results.size());
+		// Assert all requested fields are in _source
+		JsonObject source = results.get(0).asJsonObject().getJsonObject("_source");
+		assertTrue(source.containsKey("location"));
+		assertTrue(source.containsKey("fileSize"));
+
+		String firstSearchAfter = responseObject.getJsonObject("search_after").toString();
 		JsonObject firstSearchAfterObject = Utils.parseJsonObject(firstSearchAfter);
 		JsonArray firstFields = firstSearchAfterObject.getJsonArray("fields");
 		int firstDoc = firstSearchAfterObject.getJsonNumber("doc").intValueExact();
@@ -519,8 +556,9 @@ public class UserResourceTest {
 		assertEquals(200, response.getStatus());
 		responseObject = Utils.parseJsonObject(response.getEntity().toString());
 		results = responseObject.getJsonArray("results");
-		String secondSearchAfter = responseObject.getJsonObject("search_after").toString();
 		assertEquals(3, results.size());
+		assertTrue(responseObject.containsKey("search_after"));
+		String secondSearchAfter = responseObject.getJsonObject("search_after").toString();
 		JsonObject secondSearchAfterObject = Utils.parseJsonObject(secondSearchAfter);
 		JsonArray secondFields = secondSearchAfterObject.getJsonArray("fields");
 		assertEquals(0, secondSearchAfterObject.getJsonNumber("shardIndex").intValueExact());


### PR DESCRIPTION
Closes #111 

Changes as described on #111.
Also run into a hard to diagnose error where I was using an outdated config, and `PriorityMap` failed to parse the JSON. While the solution was to update my local install `run.properties` to match the latest `run.properties.example`, I also amended the code that reads the JSON to failover to the default setting and increased the logging in this area.