### PR TITLE
New CartChecker class to poll for deletion of old Carts #117

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -42,6 +42,11 @@ facility.LILS.limit.count = 250000
 # Maximum total volume, in bytes, that can be included in a single cart request.
 facility.LILS.limit.size = 10000000000000
 
+# Optionally delete carts that have not been updated in the last N days
+# Different limits can be set for anonymous (as defined above) and authenticated users
+# facility.LILS.maxCartAgeDays.anon=7
+# facility.LILS.maxCartAgeDays.authenticated=30
+
 # enable send email
 mail.enable=true
 

--- a/src/main/java/org/icatproject/topcat/CartChecker.java
+++ b/src/main/java/org/icatproject/topcat/CartChecker.java
@@ -1,0 +1,82 @@
+package org.icatproject.topcat;
+
+import org.icatproject.topcat.exceptions.InternalException;
+import org.icatproject.topcat.repository.CartRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.ejb.EJB;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.Singleton;
+
+@Singleton
+public class CartChecker {
+    private static final Logger logger = LoggerFactory.getLogger(CartChecker.class);
+    private String anonUserName;
+    private FacilityMap facilityMap;
+
+    @EJB
+    private CartRepository cartRepository;
+
+    /**
+     * @throws InternalException if FacilityMap fails to intitalise due to a bad
+     *                           properties file
+     */
+    public CartChecker() throws InternalException {
+        this.anonUserName = Properties.getInstance().getProperty("anonUserName", "");
+        this.facilityMap = FacilityMap.getInstance();
+    }
+
+    /**
+     * Constructor for use in testing where specific parameters may be needed.
+     * 
+     * @param anonUserName   Anonymous username without session id suffix
+     * @param facilityMap    Map of facility specific properties
+     * @param cartRepository EJB for managing Cart entities
+     */
+    public CartChecker(String anonUserName, FacilityMap facilityMap, CartRepository cartRepository) {
+        this.anonUserName = anonUserName;
+        this.facilityMap = facilityMap;
+        this.cartRepository = cartRepository;
+    }
+
+    /**
+     * Poll for the deletion of old carts at midnight.
+     */
+    @Schedule(hour = "0", minute = "0", second = "0")
+    void poll() {
+        logger.trace("Beginning deletion of old carts");
+        try {
+            for (String facilityName : facilityMap.getFacilities()) {
+                if (!anonUserName.equals("")) {
+                    removeOldCarts(facilityName, facilityMap.getMaxCartAgeDaysAnon(facilityName), true);
+                }
+                removeOldCarts(facilityName, facilityMap.getMaxCartAgeDaysAuthenticated(facilityName), false);
+            }
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+        }
+        logger.trace("Deletion of old carts completed");
+    }
+
+    /**
+     * Deletes Carts from the specified facilityName that are older than
+     * maxCartAgeDays.
+     * 
+     * @param facilityName   Cart facilityName to query for
+     * @param maxCartAgeDays Only Carts where updatedAt is older than this will be
+     *                       deleted
+     * @param isAnon         Whether to delete carts that do (or do not) match
+     *                       anonUserName
+     */
+    public void removeOldCarts(String facilityName, Integer maxCartAgeDays, boolean isAnon) {
+        if (maxCartAgeDays != null) {
+            int numberDeleted = cartRepository.deleteCarts(facilityName, maxCartAgeDays, anonUserName, isAnon);
+            String format = "Deleted {} Carts over {} days old for {} users at {}";
+            logger.info(format, numberDeleted, maxCartAgeDays, isAnon ? "anon" : "authenticated", facilityName);
+        } else {
+            String format = "Deletion of carts disabled for {} users at {}";
+            logger.trace(format, isAnon ? "anon" : "authenticated", facilityName);
+        }
+    }
+}

--- a/src/main/java/org/icatproject/topcat/FacilityMap.java
+++ b/src/main/java/org/icatproject/topcat/FacilityMap.java
@@ -14,6 +14,8 @@ public class FacilityMap {
         public String idsUrl;
 		public Long countLimit = null;
 		public Long sizeLimit = null;
+		public Integer maxCartAgeDaysAnon = null;
+		public Integer maxCartAgeDaysAuthenticated = null;
     }
 	
     private static FacilityMap instance = null;
@@ -88,6 +90,16 @@ public class FacilityMap {
 				facility.sizeLimit = Long.valueOf(sizeString);
 			}
 
+			String maxCartAgeDaysRoot = "facility." + facilityName + ".maxCartAgeDays.";
+			String maxCartAgeDaysAnonString = properties.getProperty(maxCartAgeDaysRoot + "anon");
+			if (maxCartAgeDaysAnonString != null) {
+				facility.maxCartAgeDaysAnon = Integer.valueOf(maxCartAgeDaysAnonString);
+			}
+			String maxCartAgeDaysAuthenticatedString = properties.getProperty(maxCartAgeDaysRoot + "authenticated");
+			if (maxCartAgeDaysAuthenticatedString != null) {
+				facility.maxCartAgeDaysAuthenticated = Integer.valueOf(maxCartAgeDaysAuthenticatedString);
+			}
+
 			facilityMapping.put(facilityName, facility);
 		}
 	}
@@ -154,6 +166,26 @@ public class FacilityMap {
 	public Long getSizeLimit(String facilityName) throws InternalException {
 		Facility facility = getFacility(facilityName);
 		return facility.sizeLimit;
+	}
+
+	/**
+	 * @param facilityName ICAT Facility.name
+	 * @return Limit on the maximum age of an anonymous user's cart in days, or null if not set
+	 * @throws InternalException if facilityName is not a key in facilityMapping
+	 */
+	public Integer getMaxCartAgeDaysAnon(String facilityName) throws InternalException {
+		Facility facility = getFacility(facilityName);
+		return facility.maxCartAgeDaysAnon;
+	}
+
+	/**
+	 * @param facilityName ICAT Facility.name
+	 * @return Limit on the maximum age of an authenticated user's cart in days, or null if not set
+	 * @throws InternalException if facilityName is not a key in facilityMapping
+	 */
+	public Integer getMaxCartAgeDaysAuthenticated(String facilityName) throws InternalException {
+		Facility facility = getFacility(facilityName);
+		return facility.maxCartAgeDaysAuthenticated;
 	}
 
 	/**

--- a/src/main/java/org/icatproject/topcat/repository/CartRepository.java
+++ b/src/main/java/org/icatproject/topcat/repository/CartRepository.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.NoResultException;
 
+import org.apache.commons.lang3.time.DateUtils;
 import org.icatproject.topcat.domain.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,53 @@ public class CartRepository {
         } catch(NoResultException e){
             return null;
         }
+    }
+
+    /**
+     * @param userName     Cart userName
+     * @param facilityName Cart facilityName
+     * @return new, persisted Cart with the specified parameters
+     */
+    public Cart createCart(String userName, String facilityName) {
+        Cart cart = new Cart();
+        cart.setFacilityName(facilityName);
+        cart.setUserName(userName);
+        em.persist(cart);
+        em.flush();
+        return cart;
+    }
+
+    /**
+     * Deletes Carts from the specified facilityName that are older than
+     * maxCartAgeDays. Can optionally for just anonymous users, just authenticated
+     * users, or both.
+     * 
+     * @param facilityName   Cart facilityName to query for
+     * @param maxCartAgeDays Only Carts where updatedAt is older than this will be
+     *                       deleted
+     * @param anonUserName   If defined, will include a clause selecting based on
+     *                       whether userName matches
+     * @param isAnon         Only used if anonUserName is not empty. If true, clause
+     *                       on userName is LIKE, if false NOT LIKE.
+     * @return number of rows deleted
+     */
+    public int deleteCarts(String facilityName, int maxCartAgeDays, String anonUserName, boolean isAnon) {
+        TypedQuery<Cart> query;
+        String qlString = "DELETE FROM Cart cart";
+        qlString += " WHERE cart.facilityName = :facilityName AND cart.updatedAt < :updatedAt";
+        if (anonUserName.equals("")) {
+            query = em.createQuery(qlString, Cart.class);
+        } else {
+            if (isAnon) {
+                query = em.createQuery(qlString + " AND cart.userName LIKE :anonPrefix", Cart.class);
+            } else {
+                query = em.createQuery(qlString + " AND cart.userName NOT LIKE :anonPrefix", Cart.class);
+            }
+            query.setParameter("anonPrefix", anonUserName + "/%");
+        }
+        query.setParameter("facilityName", facilityName);
+        query.setParameter("updatedAt", DateUtils.addDays(new Date(), -maxCartAgeDays));
+        return query.executeUpdate();
     }
 
 }

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -471,13 +471,8 @@ public class UserResource {
 		String userName = icatClient.getUserName();
 		String cartUserName = getCartUserName(userName, sessionId);
 		Cart cart = cartRepository.getCart(cartUserName, facilityName);
-
 		if (cart == null) {
-			cart = new Cart();
-			cart.setFacilityName(facilityName);
-			cart.setUserName(cartUserName);
-			em.persist(cart);
-			em.flush();
+			cart = cartRepository.createCart(cartUserName, facilityName);
 		}
 
 		Map<Long, Boolean> isInvestigationIdIndex = new HashMap<Long, Boolean>();

--- a/src/test/java/org/icatproject/topcat/CartCheckerTest.java
+++ b/src/test/java/org/icatproject/topcat/CartCheckerTest.java
@@ -1,0 +1,108 @@
+package org.icatproject.topcat;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.icatproject.topcat.exceptions.InternalException;
+import org.icatproject.topcat.repository.CartRepository;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.arquillian.transaction.api.annotation.Transactional;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ejb.EJB;
+import jakarta.inject.Inject;
+
+@ArquillianTest
+public class CartCheckerTest {
+    private static final String anonUserName = "anon/anon/00000000-0000-0000-0000-000000000000";
+    private static final String authenticatedUserName = "simple/root";
+    private static final String facilityName = "LILS";
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(CartChecker.class, CartRepository.class)
+                .addPackages(true, "org.icatproject.topcat.domain", "org.icatproject.topcat.exceptions")
+                .addAsResource("META-INF/persistence.xml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @EJB
+    private CartRepository cartRepository;
+
+    @Inject
+    private CartChecker cartChecker;
+
+    @BeforeAll
+    public static void beforeAll() {
+        TestHelpers.installTrustManager();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        cartRepository.createCart(anonUserName, facilityName);
+        cartRepository.createCart(authenticatedUserName, facilityName);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        cartRepository.deleteCarts(facilityName, 0, "", false);
+    }
+
+    @Test
+    @Transactional
+    public void testAnonUserNameUndefined() throws InternalException {
+        MockProperties props = new MockProperties();
+        props.setMockProperty("facility.list", "LILS");
+        props.setMockProperty("facility.LILS.icatUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.idsUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.anon", "0");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.authenticated", "0");
+        new CartChecker("", new FacilityMap(props), cartRepository).poll();
+        assertNull(cartRepository.getCart(anonUserName, facilityName));
+        assertNull(cartRepository.getCart(authenticatedUserName, facilityName));
+    }
+
+    @Test
+    @Transactional
+    public void testDeleted() throws InternalException {
+        MockProperties props = new MockProperties();
+        props.setMockProperty("facility.list", "LILS");
+        props.setMockProperty("facility.LILS.icatUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.idsUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.anon", "0");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.authenticated", "0");
+        new CartChecker("anon/anon", new FacilityMap(props), cartRepository).poll();
+        assertNull(cartRepository.getCart(anonUserName, facilityName));
+        assertNull(cartRepository.getCart(authenticatedUserName, facilityName));
+    }
+
+    @Test
+    @Transactional
+    public void testDisabled() throws InternalException {
+        cartChecker.poll();
+        assertNotNull(cartRepository.getCart(anonUserName, facilityName));
+        assertNotNull(cartRepository.getCart(authenticatedUserName, facilityName));
+    }
+
+    @Test
+    @Transactional
+    public void testNotDeleted() throws InternalException {
+        MockProperties props = new MockProperties();
+        props.setMockProperty("facility.list", "LILS");
+        props.setMockProperty("facility.LILS.icatUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.idsUrl", "https://localhost:8181");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.anon", "30");
+        props.setMockProperty("facility.LILS.maxCartAgeDays.authenticated", "30");
+        new CartChecker("anon/anon", new FacilityMap(props), cartRepository).poll();
+        assertNotNull(cartRepository.getCart(anonUserName, facilityName));
+        assertNotNull(cartRepository.getCart(authenticatedUserName, facilityName));
+    }
+}


### PR DESCRIPTION
Branched from `106_queue_carts` to get refactor of `MockProperties`.

* New `CartChecker` class which polls for the deletion of anon/authenticated Carts based on configurable ages
* Include new properties in `run.properties.example` and `FacilityMap`
* Refactor code to create new Carts to `CartRepository` (now also used in test setup)
* Add deletion method to `CartRepository`
* Test class

Closes #117 